### PR TITLE
load domain-specific configuration if matching file exists

### DIFF
--- a/config.js
+++ b/config.js
@@ -1,4 +1,5 @@
 var convict = require('convict');
+var fs = require('fs');
 
 // Define a schema
 var conf = convict({
@@ -252,6 +253,25 @@ conf.loadFile('./config/config.' + env + '.json');
 
 // Perform validation
 conf.validate({strict: false});
+
+// Load domain-specific configuration
+conf.updateConfigDataForDomain = function(domain) {
+  var domainConfig = './config/' + domain + '.json';
+  try {
+    var stats = fs.statSync(domainConfig);
+    // no error, file exists
+    conf.loadFile(domainConfig);
+    conf.validate({strict: false});
+  }
+  catch(err) {
+    if (err.code === 'ENOENT') {
+      //console.log('No domain-specific configuration file: ' + domainConfig);
+    }
+    else {
+      console.log(err);
+    }
+  }
+};
 
 module.exports = conf;
 module.exports.configPath = function() {

--- a/dadi/lib/index.js
+++ b/dadi/lib/index.js
@@ -58,6 +58,15 @@ Server.prototype.start = function (done) {
     app.use(bodyParser.urlencoded({ extended: false, limit: '50mb' }));
     app.use(bodyParser.text({ limit: '50mb' }));
 
+    // update configuration based on domain
+    var domainConfigLoaded;
+    app.use(function(req, res, next) {
+      if (domainConfigLoaded) return next();
+      config.updateConfigDataForDomain(req.headers.host);
+      domainConfigLoaded = true;
+      return next();
+    });
+
     // configure authentication middleware
     auth(self);
 


### PR DESCRIPTION
If, for the current domain, there exists a file in /config with a filename matching the domain... load it.

e.g.

```
/config
  127.0.0.1:3001.json
  api.empireonline.com.json
```

Closes #14 .
