### PR TITLE
Validate passed skip & page parameters

### DIFF
--- a/test/acceptance/app.js
+++ b/test/acceptance/app.js
@@ -1219,6 +1219,78 @@ describe('Application', function () {
                     });
                 });
 
+                it('should return 400 if invalid skip option is provided', function (done) {
+                    var client = request(connectionString);
+
+                    client
+                    .get('/vtest/testdb/test-schema?skip=-1')
+                    .set('Authorization', 'Bearer ' + bearerToken)
+                    .expect(400)
+                    .expect('content-type', 'application/json')
+                    .end(function (err, res) {
+                        if (err) return done(err);
+
+                        res.body['errors'].should.exist;
+                        res.body['errors'][0].title.should.eql("Invalid Skip Parameter Provided");
+
+                        done();
+                    });
+                });
+
+                it('should return 400 if skip option is alphabetical', function (done) {
+                    var client = request(connectionString);
+
+                    client
+                    .get('/vtest/testdb/test-schema?skip=a')
+                    .set('Authorization', 'Bearer ' + bearerToken)
+                    .expect(400)
+                    .expect('content-type', 'application/json')
+                    .end(function (err, res) {
+                        if (err) return done(err);
+
+                        res.body['errors'].should.exist;
+                        res.body['errors'][0].title.should.eql("Invalid Skip Parameter Provided");
+
+                        done();
+                    });
+                });
+
+                it('should return 400 if invalid page option is provided', function (done) {
+                    var client = request(connectionString);
+
+                    client
+                    .get('/vtest/testdb/test-schema?page=-1')
+                    .set('Authorization', 'Bearer ' + bearerToken)
+                    .expect(400)
+                    .expect('content-type', 'application/json')
+                    .end(function (err, res) {
+                        if (err) return done(err);
+
+                        res.body['errors'].should.exist;
+                        res.body['errors'][0].title.should.eql("Invalid Page Parameter Provided");
+
+                        done();
+                    });
+                });
+
+                it('should return multiple errors if invalid page and skip options are provided', function (done) {
+                    var client = request(connectionString);
+
+                    client
+                    .get('/vtest/testdb/test-schema?page=-1&skip=-8')
+                    .set('Authorization', 'Bearer ' + bearerToken)
+                    .expect(400)
+                    .expect('content-type', 'application/json')
+                    .end(function (err, res) {
+                        if (err) return done(err);
+
+                        res.body['errors'].should.exist;
+                        res.body['errors'].length.should.eql(2);
+
+                        done();
+                    });
+                });
+
                 it('should return javascript if `callback` is provided', function (done) {
                     var client = request(connectionString);
                     var callbackName = 'testCallback';

--- a/test/unit/controller.js
+++ b/test/unit/controller.js
@@ -73,6 +73,60 @@ describe('Controller', function (done) {
                 done();
             });
 
+            it('should not call find() if invalid skip option is provided', function (done) {
+                var mod = model('testModel', help.getModelSchema());
+                var stub = sinon.stub(mod, 'find');
+
+                var req = {
+                    url: '/foo/bar?filter={"fieldName":"test"}&skip=-1'
+                };
+
+                var res = {
+                  setHeader: function setHeader(string, string) {
+                  },
+                  end: function end(body) {
+                    this.body = body;
+                  }
+                }
+
+                res.body = '';
+                res.statusCode = 200;
+
+                controller(mod).get(req, res, {});
+                stub.restore();
+                stub.callCount.should.equal(0);
+
+                res.statusCode.should.eql(400);
+                done();
+            });
+
+            it('should not call find() if invalid page option is provided', function (done) {
+                var mod = model('testModel', help.getModelSchema());
+                var stub = sinon.stub(mod, 'find');
+
+                var req = {
+                    url: '/foo/bar?filter={"fieldName":"test"}&page=-1'
+                };
+
+                var res = {
+                  setHeader: function setHeader(string, string) {
+                  },
+                  end: function end(body) {
+                    this.body = body;
+                  }
+                }
+
+                res.body = '';
+                res.statusCode = 200;
+
+                controller(mod).get(req, res, {});
+
+                stub.restore();
+                stub.callCount.should.equal(0);
+                res.statusCode.should.eql(400);
+                done();
+            });
+
             it('should pass model\'s default filters to the find query', function (done) {
                 var mod = model('testModel', null, help.getModelSchemaWithMultipleFields(), help.getModelSettings());
                 var stub = sinon.stub(mod, 'find');


### PR DESCRIPTION
Before attempting model.find() to ensure we have sane params to pass to Mongo. 

An error will be returned for invalid parameters.

Closes #18.
