### PR TITLE
change all boolean values to empty string

### DIFF
--- a/config.js
+++ b/config.js
@@ -60,8 +60,8 @@ var conf = convict({
       },
       replicaSet: {
         doc: "",
-        format: Boolean,
-        default: false
+        format: String,
+        default: ""
       },
       enableCollectionDatabases: {
         doc: "",

--- a/config/config.development.json.sample
+++ b/config/config.development.json.sample
@@ -17,7 +17,7 @@
     "password": "",
     "database": "api",
     "ssl": false,
-    "replicaSet": false,
+    "replicaSet": "",
     "enableCollectionDatabases": false,
     "secondary": {
       "hosts": [
@@ -28,7 +28,7 @@
       ],
       "username": "",
       "password": "",
-      "replicaSet": false,
+      "replicaSet": "",
       "ssl": false
     },
     "testdb": {

--- a/config/config.production.json.sample
+++ b/config/config.production.json.sample
@@ -17,7 +17,7 @@
     "password": "",
     "database": "api",
     "ssl": false,
-    "replicaSet": false,
+    "replicaSet": "",
     "enableCollectionDatabases": false,
     "secondary": {
       "hosts": [
@@ -28,7 +28,7 @@
       ],
       "username": "",
       "password": "",
-      "replicaSet": false,
+      "replicaSet": "",
       "ssl": false
     },
     "testdb": {

--- a/config/config.qa.json.sample
+++ b/config/config.qa.json.sample
@@ -17,7 +17,7 @@
     "password": "",
     "database": "test",
     "ssl": false,
-    "replicaSet": false,
+    "replicaSet": "",
     "enableCollectionDatabases": false,
     "secondary": {
       "hosts": [
@@ -28,7 +28,7 @@
       ],
       "username": "",
       "password": "",
-      "replicaSet": false,
+      "replicaSet": "",
       "ssl": false
     },
     "testdb": {

--- a/config/config.test.json.sample
+++ b/config/config.test.json.sample
@@ -17,7 +17,7 @@
     "password": "",
     "database": "test",
     "ssl": false,
-    "replicaSet": false,
+    "replicaSet": "",
     "enableCollectionDatabases": false,
     "secondary": {
       "hosts": [
@@ -28,7 +28,7 @@
       ],
       "username": "",
       "password": "",
-      "replicaSet": false,
+      "replicaSet": "",
       "ssl": false
     },
     "testdb": {

--- a/test/acceptance/model.js
+++ b/test/acceptance/model.js
@@ -21,7 +21,7 @@ describe('Model', function () {
           "password": "",
           "database": "test",
           "ssl": false,
-          "replicaSet": false,
+          "replicaSet": "",
           "enableCollectionDatabases": true,
           "secondary": {
               "hosts": [
@@ -32,7 +32,7 @@ describe('Model', function () {
               ],
               "username": "",
               "password": "",
-              "replicaSet": false,
+              "replicaSet": "",
               "ssl": false
           }
     }
@@ -69,7 +69,7 @@ describe('Model', function () {
           "password": "",
           "database": "test",
           "ssl": false,
-          "replicaSet": false,
+          "replicaSet": "",
           "enableCollectionDatabases": false,
           "secondary": {
               "hosts": [
@@ -80,7 +80,7 @@ describe('Model', function () {
               ],
               "username": "",
               "password": "",
-              "replicaSet": false,
+              "replicaSet": "",
               "ssl": false
           }
     }
@@ -113,7 +113,7 @@ describe('Model', function () {
           "password": "serama123",
           "database": "test",
           "ssl": false,
-          "replicaSet": false,
+          "replicaSet": "",
           "enableCollectionDatabases": true
     }
 
@@ -145,7 +145,7 @@ describe('Model', function () {
           "password": "serama123",
           "database": "test",
           "ssl": false,
-          "replicaSet": false,
+          "replicaSet": "",
           "enableCollectionDatabases": true,
           "secondary": {
 
@@ -180,7 +180,7 @@ describe('Model', function () {
           "password": "",
           "database": "test",
           "ssl": false,
-          "replicaSet": false,
+          "replicaSet": "",
           "enableCollectionDatabases": true,
           "secondary": {
             "hosts": [

--- a/test/unit/model/connection.js
+++ b/test/unit/model/connection.js
@@ -32,7 +32,7 @@ describe('Model connection', function () {
             "username": "",
             "password": "",
             "database": "test",
-            "replicaSet": false,
+            "replicaSet": "",
             "hosts": [
                 {
                     "host": "127.0.0.1",
@@ -70,7 +70,7 @@ describe('Model connection', function () {
                     host: '127.0.0.1',
                     port: 27017
                 }],
-                replicaSet: false
+                replicaSet: ""
             });
 
             conn.on('connect', function (db) {

--- a/test/unit/model/index.js
+++ b/test/unit/model/index.js
@@ -46,7 +46,7 @@ describe('Model', function () {
                 "username": "",
                 "password": "",
                 "database": "test",
-                "replicaSet": false,
+                "replicaSet": "",
                 "hosts": [
                     {
                         "host": "localhost",


### PR DESCRIPTION
Fix #19 

The issue here was an incorrect data type for the configuration file. The config schema (`config.js`) has been modified to use a `String` datatype rather than a `Boolean`, and occurrences of `replicaSet: false` replaced with `replicaSet: ""`

@mingard please review.
