### PR TITLE
Add logging level configuration

### DIFF
--- a/config.js
+++ b/config.js
@@ -170,6 +170,11 @@ var conf = convict({
       format: Boolean,
       default: true
     },
+    level: {
+      doc: "Sets the logging level.",
+      format: ['debug','info','warn','error','trace'],
+      default: 'info'
+    },
     path: {
       doc: "The absolute or relative path to the directory for log files.",
       format: String,

--- a/dadi/lib/log.js
+++ b/dadi/lib/log.js
@@ -9,7 +9,6 @@ var _ = require('underscore');
 var config = require(path.resolve(__dirname + '/../../config'));
 var options = config.get('logging');
 //var awsConfig = config.get('aws');
-var enabled = options.enabled;
 var logPath = path.resolve(options.path + '/' + options.filename + '.' + config.get('env') + '.' + options.extension);
 var accessLogPath = path.resolve(options.path + '/' + options.filename + '.access.' + options.extension);
 var accessLog;
@@ -56,8 +55,12 @@ if (options.accessLog.enabled) {
 
 var self = module.exports = {
 
+  enabled: function(level) {
+    return config.get('logging').enabled && (bunyan.resolveLevel(level) >= bunyan.resolveLevel(config.get('logging.level')));
+  },
+
   access: function access() {
-    if (enabled && options.accessLog.enabled) {
+    if (options.accessLog.enabled) {
       try {
         accessLog.info.apply(accessLog, arguments);
       }
@@ -68,23 +71,23 @@ var self = module.exports = {
   },
 
   debug: function debug() {
-    if (enabled) log.debug.apply(log, arguments);
+    if (self.enabled('debug')) log.debug.apply(log, arguments);
   },
 
   info: function info() {
-    if (enabled) log.info.apply(log, arguments);
+    if (self.enabled('info')) log.info.apply(log, arguments);
   },
 
   warn: function warn() {
-    if (enabled) log.warn.apply(log, arguments);
+    if (self.enabled('warn')) log.warn.apply(log, arguments);
   },
 
   error: function error() {
-    if (enabled) log.error.apply(log, arguments);
+    if (self.enabled('error')) log.error.apply(log, arguments);
   },
 
   trace: function trace() {
-    if (enabled) log.trace.apply(log, arguments);
+    if (self.enabled('trace')) log.trace.apply(log, arguments);
   },
 
   get: function get() {

--- a/test/unit/log.js
+++ b/test/unit/log.js
@@ -69,6 +69,23 @@ describe('logger', function () {
           done();
         });
 
+        it('should not log when config level doesn\'t allow', function (done) {
+
+          config.set('logging.level', 'info');
+
+          var message = 'Hello';
+
+          var logger = log.get();
+          var method = sinon.spy(logger, 'debug');
+
+          log.debug(message);
+          logger.debug.restore();
+
+          method.called.should.eql(false);
+
+          done();
+        });
+
         it('should use bunyan log.warn when log.stage is called', function (done) {
 
           var message = 'Hello';
@@ -115,6 +132,7 @@ describe('logger', function () {
         });
 
         it('should use bunyan log.debug when log.debug is called', function (done) {
+          config.set('logging.level', 'debug');
           var message = 'Hello';
           var logger = log.get();
           var method = sinon.spy(logger, 'debug');
@@ -145,12 +163,14 @@ describe('logger', function () {
         });
 
         it('should use bunyan log.trace when log.trace is called', function (done) {
+          config.set('logging.level', 'trace');
           var message = 'Hello';
           var logger = log.get();
           var method = sinon.spy(logger, 'trace');
           log.trace(message);
           logger.trace.restore();
           method.called.should.eql(true);
+          config.set('logging.level', 'info');
           done();
         });
 


### PR DESCRIPTION
This pull request adds a new config option for logging level, which can be one of debug, info, warn, trace, error. This is designed to limit the amount of logging performed during normal usage.

Close #28 