### PR TITLE
Standard log rotation

### DIFF
--- a/config.js
+++ b/config.js
@@ -190,6 +190,16 @@ var conf = convict({
       format: String,
       default: "log"
     },
+    fileRotationPeriod: {
+      doc: "The period at which to rotate the log file. This is a string of the format '$number$scope' where '$scope' is one of 'ms' (milliseconds), 'h' (hours), 'd' (days), 'w' (weeks), 'm' (months), 'y' (years). The following names can be used 'hourly' (= '1h'), 'daily (= '1d'), 'weekly' ('1w'), 'monthly' ('1m'), 'yearly' ('1y').",
+      format: String,
+      default: ""  // disabled
+    },
+    fileRetentionCount: {
+      doc: "The number of rotated log files to keep.",
+      format: Number,
+      default: 7    // keep 7 back copies
+    },
     accessLog: {
       enabled: {
         doc: "If true, HTTP access logging is enabled. The log file name is similar to the setting used for normal logging, with the addition of 'access'. For example `api.access.log`.",

--- a/dadi/lib/log.js
+++ b/dadi/lib/log.js
@@ -27,15 +27,29 @@ mkdirp(path.resolve(options.path), {}, function(err, made) {
 var log = bunyan.createLogger({
   name: 'dadi-api',
   serializers: bunyan.stdSerializers,
-  streams: [
-    { level: 'info', path: logPath },
-    { level: 'error', path: logPath }
-  ]
+  streams: getStreams()
 });
+
+function getStreams() {
+  if (options.fileRotationPeriod !== '') {
+    return [
+      { level: 'info', type: 'rotating-file', path: logPath, period: options.fileRotationPeriod, count: options.fileRetentionCount },
+      { level: 'warn', type: 'rotating-file', path: logPath, period: options.fileRotationPeriod, count: options.fileRetentionCount },
+      { level: 'error', type: 'rotating-file', path: logPath, period: options.fileRotationPeriod, count: options.fileRetentionCount }
+    ]
+  }
+  else {
+    return [
+      { level: 'info', path: logPath },
+      { level: 'warn', path: logPath },
+      { level: 'error', path: logPath }
+    ]
+  }
+}
 
 // add console logger
 if (config.get('env') === 'development') {
-  //log.addStream({ level: 'debug', stream: process.stdout });
+  log.addStream({ level: 'debug', stream: process.stdout });
 }
 
 if (options.accessLog.enabled) {


### PR DESCRIPTION
This pull request adds the ability to set standard log files to rotate the same way as the access log does. 

The default setting is "" which means the rotation is disabled.

```
logging: {
  fileRotationPeriod: "1d"  
  fileRetentionCount: 7    // keep 7 back copies
}
```

Close #30 