### PR TITLE
Feature/use put for updates

### DIFF
--- a/dadi/lib/controller/index.js
+++ b/dadi/lib/controller/index.js
@@ -210,6 +210,10 @@ Controller.prototype.post = function (req, res, next) {
     });
 }
 
+Controller.prototype.put = function (req, res, next) {
+  return this.post(req, res, next);
+}
+
 Controller.prototype.delete = function (req, res, next) {
     var id = req.params.id;
     if (!id) return next();

--- a/test/acceptance/cache.js
+++ b/test/acceptance/cache.js
@@ -384,7 +384,7 @@ describe('Cache', function (done) {
       });
     });
 
-    it('should flush on POST update request', function (done) {
+    it('should flush on PUT update request', function (done) {
   	   this.timeout(4000);
 
       help.createDoc(bearerToken, function (err, doc) {
@@ -427,7 +427,7 @@ describe('Cache', function (done) {
 
                   // UPDATE again
                   client
-                  .post('/vtest/testdb/test-schema/' + id)
+                  .put('/vtest/testdb/test-schema/' + id)
                   .set('Authorization', 'Bearer ' + bearerToken)
                   .send({field1: 'foo bar baz!'})
                   .expect(200)
@@ -895,7 +895,7 @@ describe('Cache', function (done) {
       }
     });
 
-    it('should flush on POST update request', function(done) {
+    it('should flush on PUT update request', function(done) {
       this.timeout(4000);
 
       delete require.cache[__dirname + '/../../config.js'];
@@ -956,7 +956,7 @@ describe('Cache', function (done) {
 
                            // UPDATE again
                            client
-                           .post('/vtest/testdb/test-schema/' + id)
+                           .put('/vtest/testdb/test-schema/' + id)
                            .set('Authorization', 'Bearer ' + bearerToken)
                            .send({field1: 'foo bar baz!'})
                            .expect(200)

--- a/test/unit/controller.js
+++ b/test/unit/controller.js
@@ -228,11 +228,33 @@ describe('Controller', function (done) {
 
                 done();
             });
+          });
+
+          describe('`put` method', function () {
+            it('should be accessible', function (done) {
+                var mod = model('testModel', help.getModelSchema());
+                controller(mod).put.should.be.Function;
+                done();
+            });
+
+            it('should call the Model\'s update method', function (done) {
+                var mod = model('testModel');
+                var stub = sinon.stub(mod, 'update');
+                controller(mod).put({
+                    params: { id: '1234567890'},
+                    body: { field1: 'foo' },
+                    url: '/vtest/testdb/testcoll'
+                });
+                var count = stub.callCount;
+                stub.restore();
+                count.should.equal(1);
+                done();
+            });
 
             it('should add internally calculated fields during update', function (done) {
                 var mod = model('testModel');
                 var stub = sinon.stub(mod, 'update');
-                controller(mod).post({
+                controller(mod).put({
                     params: {id: '1234567890'},
                     client: {clientId: 'clientTestId'},
                     body: { field1: 'bar' },


### PR DESCRIPTION
This pull request introduces a PUT method on the controller for updating collection documents. Adding this allows finer control over authorization required by PR #20 

This change is backwards compatible - existing clients will continue to work if they are sending updates as POST requests.