### PR TITLE
Add before and after hooks

### DIFF
--- a/dadi/lib/model/hook.js
+++ b/dadi/lib/model/hook.js
@@ -3,9 +3,12 @@ var config = require(__dirname + '/../../../config');
 /**
  * Creates a new hook. Allowed types:
  *
- * 0: Create
- * 1: Update
- * 2: Delete
+ * beforeCreate
+ * afterCreate
+ * beforeUpdate
+ * afterUpdate
+ * beforeDelete
+ * afterDelete
  *
  * @param Mixed Hook data
  * @param Number Hook type
@@ -34,18 +37,33 @@ var Hook = function (data, type) {
  */
 Hook.prototype.apply = function () {
   switch (this.type) {
-    case 0: // Create
+    case 'beforeCreate':
       return this.hook(arguments[0], this.type, {
         options: this.options
       });
 
-    case 1: // Update
+    case 'afterCreate':
+      return this.hook(arguments[0], this.type, {
+        options: this.options
+      });
+
+    case 'beforeUpdate':
       return this.hook(arguments[0], this.type, {
         updatedDocs: arguments[1],
         options: this.options
       });
 
-    case 2: // Delete
+    case 'afterUpdate':
+      return this.hook(arguments[0], this.type, {
+        options: this.options
+      });
+
+    case 'beforeDelete':
+      return this.hook(arguments[0], this.type, {
+        options: this.options
+      });
+
+    case 'afterDelete':
       return this.hook(arguments[0], this.type, {
         options: this.options
       });

--- a/dadi/lib/model/index.js
+++ b/dadi/lib/model/index.js
@@ -112,11 +112,22 @@ Model.prototype.create = function (obj, internals, done) {
 
     // apply any existing `beforeCreate` hooks
     if (typeof this.settings.hooks.beforeCreate === 'object') {
+      if (obj instanceof Array) {
+        obj.forEach(function (doc) {
+          doc = this.settings.hooks.beforeCreate.reduce((function (previous, current, index) {
+              var hook = new Hook(this.settings.hooks.beforeCreate[index], 'beforeCreate');
+
+              return hook.apply(previous);
+          }).bind(this), doc);
+        }, this)
+      }
+      else {
         obj = this.settings.hooks.beforeCreate.reduce((function (previous, current, index) {
             var hook = new Hook(this.settings.hooks.beforeCreate[index], 'beforeCreate');
 
             return hook.apply(previous);
         }).bind(this), obj);
+      }
     }
 
     // internals will not be validated, i.e. should not be user input
@@ -172,11 +183,22 @@ Model.prototype.create = function (obj, internals, done) {
 
             // apply any existing `afterCreate` hooks
             if (typeof self.settings.hooks.afterCreate === 'object') {
+              if (doc instanceof Array) {
+                doc.forEach(function (d) {
+                  self.settings.hooks.afterCreate.reduce((function (previous, current, index) {
+                      var hook = new Hook(self.settings.hooks.afterCreate[index], 'afterCreate');
+
+                      return hook.apply(previous);
+                  }).bind(self), d);
+                }, self)
+              }
+              else {
                 self.settings.hooks.afterCreate.forEach(function (hookConfig, index) {
                     var hook = new Hook(self.settings.hooks.afterCreate[index], 'afterCreate');
 
                     return hook.apply(doc);
                 });
+              }
             }
 
             if (self.history) {

--- a/dadi/lib/model/index.js
+++ b/dadi/lib/model/index.js
@@ -110,10 +110,10 @@ Model.prototype.createIndex = function(done) {
  */
 Model.prototype.create = function (obj, internals, done) {
 
-    // apply any existing `create` hooks
-    if (typeof this.settings.hooks.create === 'object') {
-        obj = this.settings.hooks.create.reduce((function (previous, current, index) {
-            var hook = new Hook(this.settings.hooks.create[index], 0);
+    // apply any existing `beforeCreate` hooks
+    if (typeof this.settings.hooks.beforeCreate === 'object') {
+        obj = this.settings.hooks.beforeCreate.reduce((function (previous, current, index) {
+            var hook = new Hook(this.settings.hooks.beforeCreate[index], 'beforeCreate');
 
             return hook.apply(previous);
         }).bind(this), obj);
@@ -169,6 +169,15 @@ Model.prototype.create = function (obj, internals, done) {
             var results = {
                 results: doc
             };
+
+            // apply any existing `afterCreate` hooks
+            if (typeof self.settings.hooks.afterCreate === 'object') {
+                self.settings.hooks.afterCreate.forEach(function (hookConfig, index) {
+                    var hook = new Hook(self.settings.hooks.afterCreate[index], 'afterCreate');
+
+                    return hook.apply(doc);
+                });
+            }
 
             if (self.history) {
                 self.history.create(obj, self, function(err, res) {
@@ -492,10 +501,10 @@ Model.prototype.update = function (query, update, internals, done) {
 
             updatedDocs = docs['results'];
 
-            // apply any existing `update` hooks
-            if (typeof self.settings.hooks.update === 'object') {
-                update = self.settings.hooks.update.reduce(function (previous, current, index) {
-                    var hook = new Hook(self.settings.hooks.update[index], 1);
+            // apply any existing `beforeUpdate` hooks
+            if (typeof self.settings.hooks.beforeUpdate === 'object') {
+                update = self.settings.hooks.beforeUpdate.reduce(function (previous, current, index) {
+                    var hook = new Hook(self.settings.hooks.beforeUpdate[index], 'beforeUpdate');
 
                     return hook.apply(previous, updatedDocs);
                 }, update);
@@ -516,6 +525,16 @@ Model.prototype.update = function (query, update, internals, done) {
 
                 var results = {};
 
+                var triggerAfterUpdateHook = function (docs) {
+                    if (typeof self.settings.hooks.afterUpdate === 'object') {
+                        self.settings.hooks.afterUpdate.forEach(function (hookConfig, index) {
+                            var hook = new Hook(self.settings.hooks.afterUpdate[index], 'afterUpdate');
+
+                            return hook.apply(docs);
+                        });
+                    }
+                };
+
                 // for each of the updated documents, create
                 // a history revision for it
                 if (self.history && updatedDocs.length > 0) {
@@ -523,6 +542,9 @@ Model.prototype.update = function (query, update, internals, done) {
                         if (err) return done(err);
 
                         results.results = docs;
+
+                        // apply any existing `afterUpdate` hooks
+                        triggerAfterUpdateHook(docs);
 
                         done(null, results);
                     });
@@ -532,6 +554,9 @@ Model.prototype.update = function (query, update, internals, done) {
                         if (err) return done(err);
 
                         results = doc;
+
+                        // apply any existing `afterUpdate` hooks
+                        triggerAfterUpdateHook(doc);
 
                         done(null, results);
                     });
@@ -555,10 +580,10 @@ Model.prototype.update = function (query, update, internals, done) {
  * @api public
  */
 Model.prototype.delete = function (query, done) {
-    // apply any existing `delete` hooks
-    if (typeof this.settings.hooks.delete === 'object') {
-        query = this.settings.hooks.delete.reduce((function (previous, current, index) {
-            var hook = new Hook(this.settings.hooks.delete[index], 2);
+    // apply any existing `beforeDelete` hooks
+    if (typeof this.settings.hooks.beforeDelete === 'object') {
+        query = this.settings.hooks.beforeDelete.reduce((function (previous, current, index) {
+            var hook = new Hook(this.settings.hooks.beforeDelete[index], 'beforeDelete');
 
             return hook.apply(previous);
         }).bind(this), query);
@@ -575,7 +600,20 @@ Model.prototype.delete = function (query, done) {
 
     var self = this;
     var _done = function (database) {
-        database.collection(self.name).remove(query, done);
+        database.collection(self.name).remove(query, function (err, docs) {
+            if (!err && (docs > 0)) {
+                // apply any existing `afterDelete` hooks
+                if (typeof self.settings.hooks.afterDelete === 'object') {
+                    self.settings.hooks.afterDelete.forEach(function (hookConfig, index) {
+                        var hook = new Hook(self.settings.hooks.afterDelete[index], 'afterDelete');
+
+                        return hook.apply(query);
+                    });
+                }
+            }
+
+            done.apply(this, arguments);
+        });
     };
 
     if (this.connection.db) return _done(this.connection.db);

--- a/test/acceptance/workspace/endpoints/v1/endpoint.test-endpoint-unauth.js
+++ b/test/acceptance/workspace/endpoints/v1/endpoint.test-endpoint-unauth.js
@@ -1,0 +1,11 @@
+module.exports.get = function (req, res, next) {
+    res.setHeader('content-type', 'application/json');
+    res.statusCode = 200;
+    res.end(JSON.stringify({message: 'Hello World'}));
+};
+
+module.exports.model = {
+  "settings": {
+    "authenticate": false
+  }
+}


### PR DESCRIPTION
This is an addition to #27, with the implementation of *before* and *after* hooks, as discussed with @jimlambie. I've pushed this to a separate branch so it's easier to see all the changes and decide if there's anything that needs to be amended before merging back to the `feature/hooks` branch.

The current `create`, `update` and `delete` hooks, which are fired before the events take place, were renamed to `beforeCreate`, `beforeUpdate` and `beforeDelete`, respectively. The hooks `afterCreate`, `afterUpdate` and `afterDelete` are now introduced by this PR.

*Before* hooks are always fired, whereas *after* hooks only fire after and if an operation is successful.

## Overview

The following data is passed to each type of hook:

- `beforeCreate`:
   - `obj`: Fields sent in the request
   - `data`:
      - `options`: Hook options
- `afterCreate`:
   - `obj`: Document created in the database
   - `data`:
      - `options`: Hook options
- `beforeUpdate`:
   - `obj`: Update query sent in the request
   - `data`:
      - `options`: Hook options
      - `updatedDocs`: Documents affected by the update
- `afterUpdate`:
   - `obj`: Updated documents
   - `data`:
      - `options`: Hook options
- `beforeDelete`:
   - `obj`: Delete query sent in the request
   - `data`:
      - `options`: Hook options
- `afterDelete`:
   - `obj`: Delete query sent in the request
   - `data`:
      - `options`: Hook options

## Testing

The following hook may be useful to get a better idea of when exactly each hook type is fired and what data it receives, as it logs to the console its internals every time it gets called:

*workspace/hooks/showInfo.js*

```js
module.exports = function (obj, type, data) {
  console.log('');
  console.log('**** HOOK ***');
  console.log('Type:', type);
  console.log('Payload:', obj);
  console.log('Additional data:', data);
  console.log('');

  return obj;
};
```

And then enable it in a model:

*workspace/collections/vjoin/testdb/collection.users.json*

```js
"hooks": {
  "beforeCreate": ["showInfo"],
  "afterCreate": ["showInfo"],
  "beforeUpdate": ["showInfo"],
  "afterUpdate": ["showInfo"],
  "beforeDelete": ["showInfo"],
  "afterDelete": ["showInfo"]
}
```

Let me know your thoughts. (cc @josephdenne @jimlambie)