### PR TITLE
allow nested queries using dot notation to pass strings without conversion to ObjectID

### DIFF
--- a/dadi/lib/model/index.js
+++ b/dadi/lib/model/index.js
@@ -245,9 +245,10 @@ Model.prototype.convertApparentObjectIds = function (query) {
     }
 
     var type;
+    var keyOrParent = (key.split('.').length > 1) ? key.split('.')[0] : key
 
-    if (self.schema[key]) {
-      type = self.schema[key].type
+    if (self.schema[keyOrParent]) {
+      type = self.schema[keyOrParent].type
     }
 
     if (key === '$in') {
@@ -269,7 +270,7 @@ Model.prototype.convertApparentObjectIds = function (query) {
         query[key] = self.convertApparentObjectIds(query[key]);
       }
     }
-    else if (typeof query[key] === 'string' && ObjectID.isValid(query[key]) && query[key].match(/^[a-fA-F0-9]{24}$/)) {
+    else if (typeof query[key] === 'string' && type !== 'Object' && ObjectID.isValid(query[key]) && query[key].match(/^[a-fA-F0-9]{24}$/)) {
       query[key] = new ObjectID.createFromHexString(query[key]);
     }
   });

--- a/test/unit/model/index.js
+++ b/test/unit/model/index.js
@@ -292,7 +292,7 @@ describe('Model', function () {
             done();
         });
 
-        it('should not convert Strings to ObjectIDs when a field type is object', function (done) {
+        it('should not convert (sub query) Strings to ObjectIDs when a field type is Object', function (done) {
 
             var fields = help.getModelSchema();
             var schema = {};
@@ -315,6 +315,34 @@ describe('Model', function () {
             query = mod.convertApparentObjectIds(query);
 
             var type = typeof query.field3.id
+            type.should.eql('string');
+
+            done();
+        });
+
+        it('should not convert (dot notation) Strings to ObjectIDs when a field type is Object', function (done) {
+
+            var fields = help.getModelSchema();
+            var schema = {};
+            schema.fields = fields;
+
+            schema.fields.field2 = _.extend({}, schema.fields.fieldName, {
+                type: 'ObjectID',
+                required: false
+            });
+
+            schema.fields.field3 = _.extend({}, schema.fields.fieldName, {
+                type: 'Object',
+                required: false
+            });
+
+            var mod = model('testModelName', schema.fields);
+
+            var query = { "field3.id": "55cb1658341a0a804d4dadcc" }
+
+            query = mod.convertApparentObjectIds(query);
+
+            var type = typeof query[Object.keys(query)[0]]
             type.should.eql('string');
 
             done();


### PR DESCRIPTION
allows a query such as { "field._id": "1234567890" } through without converting the
value to an ObjectID if it resembles one (that is, 12 byte string or 24 hex chars)

will only allow this if the first part of the key (e.g. "field") can be loacted
in the schema and discovered to by an "Object" field.

Fix #54