### PR TITLE
Allow server port to be set by environment variable

### DIFF
--- a/config.js
+++ b/config.js
@@ -19,6 +19,7 @@ var conf = convict({
     port: {
       doc: "Accept connections on the specified port. A value of zero will assign a random port.",
       format: Number,
+      env: "PORT",
       default: 0
     },
     name: {

--- a/dadi/lib/index.js
+++ b/dadi/lib/index.js
@@ -89,7 +89,8 @@ Server.prototype.start = function (done) {
     search(self);
 
     // start listening
-    var server = this.server = app.listen(config.get('server.port'), config.get('server.host'));
+    var port = process.env.PORT || config.get('server.port');
+    var server = this.server = app.listen(port, config.get('server.host'));
 
     server.on('listening', function() { onListening(this) });
     server.on('error', onError);

--- a/dadi/lib/index.js
+++ b/dadi/lib/index.js
@@ -89,8 +89,7 @@ Server.prototype.start = function (done) {
     search(self);
 
     // start listening
-    var port = process.env.PORT || config.get('server.port');
-    var server = this.server = app.listen(port, config.get('server.host'));
+    var server = this.server = app.listen(config.get('server.port'), config.get('server.host'));
 
     server.on('listening', function() { onListening(this) });
     server.on('error', onError);


### PR DESCRIPTION
This PR allows the server port defined in the config to be overridden by an environmental variable. This is required when deploying to platforms like Heroku, where applications [need to comply](https://devcenter.heroku.com/articles/dynos#local-environment-variables) to these variables.

*Example:*

```
# Starting application as normal, port defined in config will be used
node server.js

# Starting application on port 1234
PORT=1234 node server.js
```

Let me know your thoughts @jimlambie @josephdenne.