### PR TITLE
feat: add DateTime type to the allowed types for collection schemas

### DIFF
--- a/dadi/lib/model/index.js
+++ b/dadi/lib/model/index.js
@@ -4,6 +4,7 @@ var help = require(__dirname + '/../help');
 var Validator = require(__dirname + '/validator');
 var History = require(__dirname + '/history');
 var Composer = require(__dirname + '/../composer').Composer;
+var moment = require('moment');
 var ObjectID = require('mongodb').ObjectID;
 var Hook = require(__dirname + '/hook');
 var _ = require('underscore');
@@ -154,8 +155,13 @@ Model.prototype.create = function (obj, internals, done) {
 
     // ObjectIDs
     obj.forEach(function (doc) {
-        doc = self.convertObjectIdsForSave(self.schema, doc);
-    });
+      doc = self.convertObjectIdsForSave(self.schema, doc);
+    })
+
+    // DateTime
+    obj.forEach(function (doc) {
+      doc = self.convertDateTimeForSave(self.schema, doc);
+    })
 
     var _done = function (database) {
         database.collection(self.name).insert(obj, function(err, doc) {
@@ -295,6 +301,16 @@ Model.prototype.convertObjectIdsForSave = function (schema, obj) {
     });
 
     return obj;
+}
+
+Model.prototype.convertDateTimeForSave = function (schema, obj) {
+  Object.keys(schema)
+  .filter(function (key) { return schema[key].type === 'DateTime' })
+  .forEach(function (key) {
+    obj[key] = new Date(moment(obj[key]).toISOString())
+  })
+
+  return obj;
 }
 
 /**
@@ -496,6 +512,8 @@ Model.prototype.update = function (query, update, internals, done) {
 
     // ObjectIDs
     update = this.convertObjectIdsForSave(this.schema, update);
+    // DateTimes
+    update = this.convertDateTimeForSave(this.schema, update);
 
     if (typeof internals === 'object' && internals != null) { // not null and not undefined
         _.extend(update, internals);

--- a/test/acceptance/fields/reference.js
+++ b/test/acceptance/fields/reference.js
@@ -1,0 +1,85 @@
+var should = require('should');
+var fs = require('fs');
+var path = require('path');
+var request = require('supertest');
+var _ = require('underscore');
+var config = require(__dirname + '/../../../config');
+var help = require(__dirname + '/../help');
+var app = require(__dirname + '/../../../dadi/lib/');
+
+// variables scoped for use throughout tests
+var bearerToken;
+var connectionString = 'http://' + config.get('server.host') + ':' + config.get('server.port');
+
+describe('Reference Field', function () {
+
+  before(function (done) {
+
+    config.set('paths.collections', 'test/acceptance/workspace/collections')
+
+    help.dropDatabase('testdb', function (err) {
+      if (err) return done(err)
+
+      app.start(function() {
+        help.getBearerToken(function (err, token) {
+          if (err) return done(err)
+          bearerToken = token;
+          done();
+        })
+      })
+    })
+  })
+
+  after(function (done) {
+    config.set('paths.collections', 'workspace/collections')
+    app.stop(done)
+  });
+
+  it('should populate a reference field containing an ObjectID', function (done) {
+
+    var person = { name: 'Ernest Hemingway' };
+    var book = { title: 'For Whom The Bell Tolls', author: null };
+
+    config.set('query.useVersionFilter', true)
+
+    var client = request(connectionString);
+    client
+    .post('/v1/library/person')
+    .set('Authorization', 'Bearer ' + bearerToken)
+    .send(person)
+    .expect(200)
+    .end(function (err, res) {
+      if (err) return done(err);
+
+      should.exist(res.body.results);
+
+      var personId = res.body.results[0]._id
+      book.author = personId
+
+      client
+      .post('/v1/library/book')
+      .set('Authorization', 'Bearer ' + bearerToken)
+      .send(book)
+      .expect(200)
+      .end(function (err, res) {
+        if (err) return done(err);
+
+        client
+        .get('/v1/library/book?compose=true')
+        .set('Authorization', 'Bearer ' + bearerToken)
+        .expect(200)
+        .end(function (err, res) {
+          if (err) return done(err);
+
+          should.exist(res.body.results)
+          var bookResult = res.body.results[0]
+          //console.log(bookResult)
+          should.exist(bookResult.author)
+          should.exist(bookResult.author.name)
+
+          done();
+        })
+      })
+    });
+  });
+})

--- a/test/acceptance/workspace/validation/collections/vtest/testdb/collection.test-validation-schema.json
+++ b/test/acceptance/workspace/validation/collections/vtest/testdb/collection.test-validation-schema.json
@@ -1,7 +1,7 @@
 {
     "fields": {
-        "fieldDate": {
-            "type": "Date",
+        "fieldDateTime": {
+            "type": "DateTime",
             "label": "Article date",
             "comments": "The date of the article",
             "placement": "Main content",

--- a/test/unit/model/validation.js
+++ b/test/unit/model/validation.js
@@ -51,6 +51,77 @@ describe('Model validator', function () {
         done();
       });
 
+      describe('DateTime', function () {
+        it('should inform of invalid DateTime', function (done) {
+          var validator = new Validator({
+            schema: {
+              field1: {
+                type: 'DateTime',
+                required: false
+              }
+            }
+          });
+          var val = validator.schema({field1: 'a123'});
+          val.success.should.be.false;
+          val.errors.length.should.equal(1);
+          val.errors[0].field.should.equal('field1');
+          val.errors[0].message.should.equal('is not a valid DateTime');
+
+          done();
+        });
+
+        it('should allow passing Strings representing a date', function (done) {
+          var validator = new Validator({
+            schema: {
+              field1: { type: 'DateTime', required: false },
+              field2: { type: 'DateTime', required: false },
+              field3: { type: 'DateTime', required: false },
+              field4: { type: 'DateTime', required: false },
+              field5: { type: 'DateTime', required: false }
+            }
+          });
+          var val = validator.schema(
+            {
+              field1: '09/12/2016',
+              field2: '2016-04-25',
+              field3: '2010-01-01T05:06:07',
+              field4: '2013-02-08T09:30:26.123+07:00',
+              field5: 'Jan 1 2001'
+            }
+          );
+          val.success.should.be.true;
+          done();
+        });
+
+        it('should allow passing a Number representing a timestamp in milliseconds', function (done) {
+          var validator = new Validator({
+            schema: {
+              field1: {
+                type: 'DateTime',
+                required: false
+              }
+            }
+          });
+          var val = validator.schema({field1: 1461820582000});
+          val.success.should.be.true;
+          done();
+        });
+
+        it('should allow passing a Number representing a timestamp in seconds', function (done) {
+          var validator = new Validator({
+            schema: {
+              field1: {
+                type: 'DateTime',
+                required: false
+              }
+            }
+          });
+          var val = validator.schema({field1: 1461820582});
+          val.success.should.be.true;
+          done();
+        });
+      })
+
       describe('ObjectID', function () {
         it('should inform of bad type for ObjectID that is not string', function (done) {
           var validator = new Validator({


### PR DESCRIPTION
Allows `type: DateTime` to be used in a collection schema's fields.

On `create` or `update` a date that can be parsed into a valid ISODate string will be stored in the database as an ISODate

**Note:** The ability to query using date manipulation is still to come.

Fix #66