### PR TITLE
Fix: Don't force Reference > ObjectId

### DIFF
--- a/dadi/lib/model/index.js
+++ b/dadi/lib/model/index.js
@@ -272,7 +272,7 @@ Model.prototype.convertApparentObjectIds = function (query) {
       if (typeof type !== 'undefined' && type === 'Object') {
         // ignore
       }
-      else {
+      else if (type !== 'Reference') {
         query[key] = self.convertApparentObjectIds(query[key]);
       }
     }


### PR DESCRIPTION
Reference field values are stored as string and should not be resolved to ObjectIds