### PR TITLE
fix: `create client` script closing of db fixed

### DIFF
--- a/utils/create-client.js
+++ b/utils/create-client.js
@@ -14,6 +14,6 @@ conn.on('connect', function (db) {
     }, function (err) {
         if (err) throw err;
 
-        conn.mongoClient.close();
+        db.close();
     });
 })


### PR DESCRIPTION
### Does this resolve an issue?
Fix/Close #71 

### Description of changes proposed in this pull request
The create-client script tries to call the close method on an undefined property. Calling `close` on the `db` object closes the connection as intended.

### Who should review this pull request?
@jimlambie shouldn't be any issues with this, but best you check!
