### PR TITLE
Add support for layout maps

### DIFF
--- a/dadi/lib/controller/index.js
+++ b/dadi/lib/controller/index.js
@@ -171,6 +171,12 @@ Controller.prototype.prepareQuery = function(req) {
     _.each(Object.keys(query), function (key) {
       if (!this.keyValidForSchema(key)) {
         delete query[key];
+      } else {
+        if (this.model.schema[key]) {
+          var fieldType = this.model.schema[key].type;
+
+          help.transformQuery(query[key], fieldType);
+        }
       }
     }, this);
   }

--- a/dadi/lib/index.js
+++ b/dadi/lib/index.js
@@ -551,7 +551,7 @@ Server.prototype.addCollectionResource = function (options) {
 
     var enableCollectionDatabases = config.get('database.enableCollectionDatabases');
     var database = enableCollectionDatabases ? options.database : null;
-    var mod = model(options.name, options.schema, null, options.schema.settings, database);
+    var mod = model(options.name, JSON.parse(fields), null, options.schema.settings, database);
     var control = controller(mod);
 
     this.addComponent({

--- a/dadi/lib/index.js
+++ b/dadi/lib/index.js
@@ -551,7 +551,7 @@ Server.prototype.addCollectionResource = function (options) {
 
     var enableCollectionDatabases = config.get('database.enableCollectionDatabases');
     var database = enableCollectionDatabases ? options.database : null;
-    var mod = model(options.name, JSON.parse(fields), null, options.schema.settings, database);
+    var mod = model(options.name, options.schema, null, options.schema.settings, database);
     var control = controller(mod);
 
     this.addComponent({

--- a/dadi/lib/model/index.js
+++ b/dadi/lib/model/index.js
@@ -19,7 +19,7 @@ var Model = function (name, schema, conn, settings, database) {
     // attach collection name
     this.name = name;
 
-    // attach fields schema
+    // attach original schema
     this.schema = schema;
 
     // attach default settings

--- a/dadi/lib/model/index.js
+++ b/dadi/lib/model/index.js
@@ -306,7 +306,7 @@ Model.prototype.convertObjectIdsForSave = function (schema, obj) {
 
 Model.prototype.convertDateTimeForSave = function (schema, obj) {
   Object.keys(schema)
-  .filter(function (key) { return schema[key].type === 'DateTime' })
+  .filter(function (key) { return ((schema[key].type === 'DateTime') && (obj[key] !== null)) })
   .forEach(function (key) {
     obj[key] = new Date(moment(obj[key]).toISOString())
   })

--- a/dadi/lib/model/layout.js
+++ b/dadi/lib/model/layout.js
@@ -1,0 +1,38 @@
+var util = require('util');
+
+var Layout = function (schema) {
+  this.schema = schema;
+};
+
+Layout.prototype.resolve = function (document) {
+  var result = document._layout.map(function (block) {
+    return {
+      source: block.source,
+      content: document[block.source][block.index]
+    };
+  });
+
+  document._layout = result;
+
+  return document;
+};
+
+Layout.prototype.validate = function (document) {
+  var errors = [];
+
+  document._layout.forEach((function (block) {
+    // Check if `source` corresponds to a field
+    if (!this.schema.fields.hasOwnProperty(block.source)) {
+      errors.push({field: '_layout', message: block.source + ' isn\'t a valid source'});
+    }
+
+    // Check if `index` is within bounds
+    if (!util.isArray(document[block.source]) || (document[block.source].length <= block.index)) {
+      errors.push({field: '_layout', message: block.index + ' isn\'t a valid index for source ' + block.source});
+    }
+  }).bind(this));
+
+  if (errors.length) return errors;
+};
+
+module.exports = Layout;

--- a/dadi/lib/model/layout.js
+++ b/dadi/lib/model/layout.js
@@ -1,34 +1,79 @@
 var util = require('util');
+var _ = require('underscore');
 
-var Layout = function (schema) {
-  this.schema = schema;
+var Layout = function (layout) {
+  this.layout = layout;
 };
 
 Layout.prototype.resolve = function (document) {
-  var result = document._layout.map(function (block) {
+  if (!document._layout) return document;
+
+  var result = {
+    beforeFree: [],
+    free: [],
+    afterFree: []
+  };
+
+  Object.keys(this.layout.fixed).forEach((function (field) {
+    if (document.hasOwnProperty(field)) {
+      var position = this.layout.fixed[field].position;
+      var destination = (position && (position < this.layout.free.position)) ? 'beforeFree' : 'afterFree';
+
+      result[destination].push({
+        type: field,
+        content: document[field]
+      });
+    }
+  }).bind(this));
+
+  result.free = document._layout.map(function (block) {
     return {
-      source: block.source,
+      type: block.source,
       content: document[block.source][block.index]
     };
   });
 
-  document._layout = result;
+  document._layout = result.beforeFree.concat(result.free).concat(result.afterFree);
 
   return document;
 };
 
 Layout.prototype.validate = function (document) {
   var errors = [];
+  var fieldCount = {};
 
-  document._layout.forEach((function (block) {
-    // Check if `source` corresponds to a field
-    if (!this.schema.fields.hasOwnProperty(block.source)) {
-      errors.push({field: '_layout', message: block.source + ' isn\'t a valid source'});
+  document._layout.forEach((function (block, blockIndex) {
+    var schemaField = this.layout.free.fields[block.source];
+
+    // Check if field is part of `free`
+    if (!schemaField) {
+      return errors.push({field: '_layout', message: 'Layout does not accept \'' + block.source + '\' as a free field'});
     }
 
     // Check if `index` is within bounds
     if (!util.isArray(document[block.source]) || (document[block.source].length <= block.index)) {
-      errors.push({field: '_layout', message: block.index + ' isn\'t a valid index for source ' + block.source});
+      return errors.push({field: '_layout', message: block.index + ' is not a valid index for field ' + block.source});
+    }
+
+    // Increment the field count and check for limits
+    if (fieldCount.hasOwnProperty(block.source)) {
+      fieldCount[block.source]++;
+    } else {
+      fieldCount[block.source] = 1;
+    }
+  }).bind(this));
+
+  Object.keys(this.layout.free.fields).forEach((function (fieldName) {
+    var schemaField = this.layout.free.fields[fieldName];
+
+    // Check for `min` limit
+    if (schemaField.min && (fieldCount[fieldName] < schemaField.min)) {
+      errors.push({field: '_layout', message: 'Layout cannot contain less than ' + schemaField.min + ' instances of \'' + fieldName + '\''});
+    }
+
+    // Check for `max` limit
+    if (schemaField.max && (fieldCount[fieldName] > schemaField.max)) {
+      errors.push({field: '_layout', message: 'Layout cannot contain more than ' + schemaField.max + ' instances of \'' + fieldName + '\''});
     }
   }).bind(this));
 

--- a/dadi/lib/model/layout.js
+++ b/dadi/lib/model/layout.js
@@ -15,21 +15,20 @@ Layout.prototype.resolve = function (document) {
   };
 
   Object.keys(this.layout.fixed).forEach((function (field) {
-    if (document.hasOwnProperty(field)) {
-      var position = this.layout.fixed[field].position;
-      var destination = (position && (position < this.layout.free.position)) ? 'beforeFree' : 'afterFree';
+    var position = this.layout.fixed[field].position;
+    var destination = (position && (position < this.layout.free.position)) ? 'beforeFree' : 'afterFree';
 
-      result[destination].push({
-        type: field,
-        content: document[field]
-      });
-    }
+    result[destination].push({
+      type: field,
+      content: document.hasOwnProperty(field) ? document[field] : null
+    });
   }).bind(this));
 
   result.free = document._layout.map(function (block) {
     return {
       type: block.source,
-      content: document[block.source][block.index]
+      content: document[block.source][block.index],
+      free: true
     };
   });
 

--- a/dadi/lib/model/validator.js
+++ b/dadi/lib/model/validator.js
@@ -82,12 +82,12 @@ function _parseDocument(obj, schema, response, layout) {
                   response.success = false;
                   response.errors.push.apply(response.errors, err);
                 }
-
-                continue;
               } else {
                 response.success = false;
                 response.errors.push({field: obj[key], message: 'does not match a layout'});
               }
+
+              continue;
             }
             else if (schema[key] && (schema[key].type === 'Mixed' || schema[key].type === 'Object')) {
                 // do nothing

--- a/dadi/lib/model/validator.js
+++ b/dadi/lib/model/validator.js
@@ -26,7 +26,6 @@ Validator.prototype.query = function (query) {
 };
 
 Validator.prototype.schema = function (obj, update) {
-
   update = update || false;
 
   // `obj` must be a "hash type object", i.e. { ... }
@@ -71,7 +70,6 @@ Validator.prototype.schema = function (obj, update) {
 };
 
 function _parseDocument(obj, schema, response) {
-
     for (var key in obj) {
         // handle objects first
         if (typeof obj[key] === 'object') {
@@ -91,6 +89,18 @@ function _parseDocument(obj, schema, response) {
                     response.success = false;
                     response.errors.push({field: key, message: err});
                 }
+            }
+            else if (util.isArray(obj[key]) && (schema[key].type === 'String')) {
+              // We allow type `String` to actually be an array of Strings. When this
+              // happens, we run the validation against the combination of all strings
+              // glued together.
+
+              var err = _validate(obj[key].join(''), schema[key], key);
+
+              if (err) {
+                  response.success = false;
+                  response.errors.push({field: key, message: err});
+              }
             }
         }
         else if (key === 'apiVersion') {
@@ -114,7 +124,6 @@ function _parseDocument(obj, schema, response) {
 }
 
 function _validate(field, schema, key) {
-
     if (schema.hasOwnProperty('validation')) {
       var validationObj = schema.validation;
 

--- a/test/acceptance/fields/reference.js
+++ b/test/acceptance/fields/reference.js
@@ -167,7 +167,7 @@ describe('Reference Field', function () {
         .end(function (err, res) {
           if (err) return done(err);
 
-          console.log(res.body)
+          //console.log(res.body)
 
           should.exist(res.body.results)
           var bookResult = res.body.results[0]

--- a/test/unit/helpTest.js
+++ b/test/unit/helpTest.js
@@ -3,176 +3,234 @@ var sinon = require('sinon');
 var help = require(__dirname + '/../../dadi/lib/help');
 
 describe('Help', function (done) {
-    describe('validateCollectionSchema', function() {
-        it('should inform of missing sections', function (done) {
-            var schema = {
+  describe('validateCollectionSchema', function() {
+    it('should inform of missing sections', function (done) {
+      var schema = {
+      }
 
-                }
-;
-            var val = help.validateCollectionSchema(schema);
-            val.success.should.be.false;
-            val.errors.length.should.equal(2);
-            val.errors[0].section.should.equal('fields');
-            val.errors[0].message.should.startWith('must be provided at least once');
+      var val = help.validateCollectionSchema(schema);
+      val.success.should.be.false;
+      val.errors.length.should.equal(2);
+      val.errors[0].section.should.equal('fields');
+      val.errors[0].message.should.startWith('must be provided at least once');
 
-            done();
-        });
-
-        it('should inform of missing settings', function (done) {
-            var schema = {
-                   fields:{
-                        "field1": {
-                            "type": "String",
-                            "label": "Title",
-                            "comments": "The title of the entry",
-                            "placement": "Main content",
-                            "validation": {},
-                            "required": false,
-                            "message": "",
-                            "display": {
-                                "index": true,
-                                "edit": true
-                            }
-                        }
-                   },
-                   settings:{cache:true}
-            };
-
-            var val = help.validateCollectionSchema(schema);
-            val.success.should.be.false;
-            val.errors[0].setting.should.equal('authenticate');
-            val.errors[0].message.should.equal('must be provided');
-
-            done();
-        });
-
-        it('should inform that minimum number of fields not supplied', function (done) {
-            var schema = {
-                   fields:{},
-                   settings:{cache:true,authenticate:true,callback:null,defaultFilters:null,fieldLimiters:null,count:10,sortOrder:1}
-                }
-;
-            var val = help.validateCollectionSchema(schema);
-            val.success.should.be.false;
-            val.errors[0].section.should.equal('fields');
-            val.errors[0].message.should.equal('must include at least one field');
-
-            done();
-        });
-
-        it('should allow field collections within primary `fields` object', function (done) {
-            var schema = {
-            "tab1": {
-                "fields": {
-                    "tab1Field1": {
-                        "type": "String",
-                        "label": "Title",
-                        "comments": "The title of the entry",
-                        "placement": "Main content",
-                        "validation": {},
-                        "required": false,
-                        "message": "",
-                        "display": {
-                            "index": true,
-                            "edit": true
-                        }
-                    }
-                }
-            },
-            "tab2": {
-                "fields": {
-                    "tab2Field1": {
-                        "type": "String"
-                    }
-                }
-            },
-            "settings":{cache:true,authenticate:true,callback:null,defaultFilters:null,fieldLimiters:null,count:10,sortOrder:1}
-            };
-
-            var val = help.validateCollectionSchema(schema);
-            val.success.should.be.true;
-
-            done();
-        });
+      done();
     });
 
-    describe('parseQuery', function () {
-        it('should export method', function (done) {
-            help.parseQuery.should.be.Function;
-            done();
-        });
-
-        it('should return correct JSON object for valid querystring', function (done) {
-            var querystring = '{ "cap_id": 2337,"year":2224,"plate":4 }';
-            var query = help.parseQuery(querystring);
-
-            var k = "", v = "";
-            for(var key in query) {
-                if(query.hasOwnProperty(key) && key == 'plate') {
-                    v = query[key];
-                    k = key;
-                    break;
-                }
+    it('should inform of missing settings', function (done) {
+      var schema = {
+           fields: {
+            "field1": {
+              "type": "String",
+              "label": "Title",
+              "comments": "The title of the entry",
+              "placement": "Main content",
+              "validation": {},
+              "required": false,
+              "message": "",
+              "display": {
+                "index": true,
+                "edit": true
+              }
             }
+           },
+           settings:{cache:true}
+      };
 
-            v.should.equal(4);
+      var val = help.validateCollectionSchema(schema);
+      val.success.should.be.false;
+      val.errors[0].setting.should.equal('authenticate');
+      val.errors[0].message.should.equal('must be provided');
 
-            done();
-        });
-
-        it('should return empty JSON object for invalid querystring', function (done) {
-            var querystring = '{ "cap_id: 2337,"year":2224,"plate":4 }';
-            var query = help.parseQuery(querystring);
-
-            var k = "", v = "";
-            for(var key in query) {
-                if(query.hasOwnProperty(key)) {
-                    v = query[key];
-                    k = key;
-                    break;
-                }
-            }
-
-            k.should.equal("");
-            v.should.equal("");
-
-            done();
-        });
-
-        it('should do nothing for querystring with leading zeroes', function (done) {
-            var querystring = '{ "title": "My 007 Movie" }';
-            var query = help.parseQuery(querystring);
-
-            var k = "", v = "";
-            for(var key in query) {
-                if(query.hasOwnProperty(key) && key == 'title') {
-                    v = query[key];
-                    k = key;
-                    break;
-                }
-            }
-
-            v.should.equal("My 007 Movie");
-
-            done();
-        });
-
-        // it('should return correct JSON object for querystring with leading zeroes', function (done) {
-        //     var querystring = '{ "cap_id": 2337,"year":2224,"plate":04 }';
-        //     var query = help.parseQuery(querystring);
-
-        //     var k = "", v = "";
-        //     for(var key in query) {
-        //         if(query.hasOwnProperty(key) && key == 'plate') {
-        //             v = query[key];
-        //             k = key;
-        //             break;
-        //         }
-        //     }
-
-        //     v.should.equal(4);
-
-        //     done();
-        // });
+      done();
     });
-});
+
+    it('should inform that minimum number of fields not supplied', function (done) {
+      var schema = {
+        fields:{},
+        settings:{cache:true,authenticate:true,callback:null,defaultFilters:null,fieldLimiters:null,count:10,sortOrder:1}
+      }
+
+      var val = help.validateCollectionSchema(schema);
+      val.success.should.be.false;
+      val.errors[0].section.should.equal('fields');
+      val.errors[0].message.should.equal('must include at least one field');
+
+      done();
+    });
+
+    it('should allow field collections within primary `fields` object', function (done) {
+      var schema = {
+      "tab1": {
+        "fields": {
+          "tab1Field1": {
+            "type": "String",
+            "label": "Title",
+            "comments": "The title of the entry",
+            "placement": "Main content",
+            "validation": {},
+            "required": false,
+            "message": "",
+            "display": {
+              "index": true,
+              "edit": true
+            }
+          }
+        }
+      },
+      "tab2": {
+        "fields": {
+          "tab2Field1": {
+            "type": "String"
+          }
+        }
+      },
+      "settings":{cache:true,authenticate:true,callback:null,defaultFilters:null,fieldLimiters:null,count:10,sortOrder:1}
+      };
+
+      var val = help.validateCollectionSchema(schema);
+      val.success.should.be.true;
+
+      done();
+    });
+  });
+
+  describe('parseQuery', function () {
+    it('should export method', function (done) {
+      help.parseQuery.should.be.Function;
+      done();
+    });
+
+    it('should return correct JSON object for valid querystring', function (done) {
+      var querystring = '{ "cap_id": 2337,"year":2224,"plate":4 }';
+      var query = help.parseQuery(querystring);
+
+      var k = "", v = "";
+      for(var key in query) {
+        if(query.hasOwnProperty(key) && key == 'plate') {
+          v = query[key];
+          k = key;
+          break;
+        }
+      }
+
+      v.should.equal(4);
+
+      done();
+    });
+
+    it('should return empty JSON object for invalid querystring', function (done) {
+      var querystring = '{ "cap_id: 2337,"year":2224,"plate":4 }';
+      var query = help.parseQuery(querystring);
+
+      var k = "", v = "";
+      for(var key in query) {
+        if(query.hasOwnProperty(key)) {
+          v = query[key];
+          k = key;
+          break;
+        }
+      }
+
+      k.should.equal("");
+      v.should.equal("");
+
+      done();
+    });
+
+    it('should do nothing for querystring with leading zeroes', function (done) {
+      var querystring = '{ "title": "My 007 Movie" }';
+      var query = help.parseQuery(querystring);
+
+      var k = "", v = "";
+      for(var key in query) {
+        if(query.hasOwnProperty(key) && key == 'title') {
+          v = query[key];
+          k = key;
+          break;
+        }
+      }
+
+      v.should.equal("My 007 Movie");
+
+      done();
+    });
+
+    // it('should return correct JSON object for querystring with leading zeroes', function (done) {
+    //   var querystring = '{ "cap_id": 2337,"year":2224,"plate":04 }';
+    //   var query = help.parseQuery(querystring);
+
+    //   var k = "", v = "";
+    //   for(var key in query) {
+    //     if(query.hasOwnProperty(key) && key == 'plate') {
+    //       v = query[key];
+    //       k = key;
+    //       break;
+    //     }
+    //   }
+
+    //   v.should.equal(4);
+
+    //   done();
+    // });
+  })
+
+  describe('transformQuery', function () {
+    it('should export method', function (done) {
+      help.transformQuery.should.be.Function;
+      done();
+    })
+
+    describe('Other fields', function () {
+      it('should return original query object if it is not a String or DateTime', function (done) {
+        var obj = { 'name': 'John' }
+        help.transformQuery(obj, 'Mixed');
+        obj.should.eql({ 'name': 'John' });
+        done();
+      })
+    })
+
+    describe('DateTime fields', function () {
+      it('should return original query object if it cannot be parsed as a Date', function (done) {
+        var obj = { 'created': 'abcedfg' }
+        help.transformQuery(obj, 'DateTime');
+        obj.should.eql({ 'created': 'abcedfg' });
+        done();
+      })
+
+      it('should return parsed Date if query object can be parsed as a Date', function (done) {
+        var obj = { 'created': '2013-02-08' }
+        help.transformQuery(obj, 'DateTime');
+        (typeof obj.created).should.eql('object')
+        done();
+      })
+    })
+
+    describe('String fields', function () {
+      it('should return original query object if it cannot be parsed as a RegExp', function (done) {
+        var obj = { 'name': 'John' }
+        help.transformQuery(obj, 'String');
+        obj.should.eql({ 'name': 'John' });
+        done();
+      })
+
+      it('should return parsed RegExp if query object can be parsed as a RegExp', function (done) {
+        var obj = { 'name': '/^john/' }
+        help.transformQuery(obj, 'String');
+        (typeof obj.name).should.eql('object')
+        obj.name.should.eql(/^john/)
+        done();
+      })
+
+      it('should return parsed RegExp if query object contains subqueries that can be parsed as a RegExp', function (done) {
+        var obj = { 'name': { '$not': '/^john/'} }
+        help.transformQuery(obj, 'String');
+        (typeof obj.name).should.eql('object')
+
+        obj.name.should.eql({ '$not': /^john/ })
+
+        done();
+      })
+    })
+  })
+})


### PR DESCRIPTION
## Overview

This PR introduces the concept of layout maps, a construct that allows a collection to deliver an aggregator of multiple instances of any field in the collection, whilst still storing data in each respective field (and therefore retaining per-field validation logic and the ability to query fields individually).

This is a powerful way of storing a mixed content field in a collection that represents an article, and comes as a requirement for the rich document editor in Publish.

## Implementation

A layout map consists of two types of fields:

- **Fixed** fields have a fixed position within the layout. Only one instance of a fixed field can exist in a layout;
- **Free** fields can have as many instances as needed, and take any position within the area reserved for them. They can specify constraints, such as a minimum or maximum number of times they can exist in a layout.

A layout isn't represented as a field. Instead, it's a map defined in `settings.layout` and identified by `_layout` in a document. It doesn't hold any actual data, but only references to blocks that are stored within the respective fields in the collection.

## Example

As an example, the combination of these two types of fields allows a collection to define an article as a sequence of:

1. A title (fixed);
2. A sequence of paragraphs, pull quotes and images, with at least one paragraph and a maximum of 5 images (free);
3. An author (fixed).

### Layout definition (in collection schema)

```json
"fields": {
  "title": {
    "type": "String"
  },
  "paragraph": {
    "type": "String"
  },
  "pullquote": {
    "type": "String"
  },
  "image": {
    "type": "Object"
  },
  "author": {
    "type": "String"
  }
},
"settings": {
  "layout": [
    {
      "source": "title"
    },
    {
      "free": true,
      "fields": [
        {
          "source": "paragraph",
          "min": 1
        },
        {
          "source": "pullquote"
        },
        {
          "source": "image",
          "max": 5
        }
      ]
    },
    {
      "source": "author"
    }
  ]	
}
```

### Inserting a document

```json
{
    "title": "This is a title",
    "author": "John Doe",
    "image": [
        {
        	"url": "http://image1.jpg",
        	"width": 1080,
        	"height": 600
        }
    ],
    "paragraph": [
        "First paragraph"
    ],
    "pullquote": [
        "First pull quote",
        "Second pull quote"
    ],
    "_layout": [
        {
            "source": "paragraph",
            "index": 0
        },
        {
            "source": "pullquote",
            "index": 0
        },
        {
            "source": "image",
            "index": 0
        },
        {
            "source": "pullquote",
            "index": 1
        }
    ]
}
```

- `source` defines which field is feeding the block
- `index` defines the position of the block within the field

### The resolved document

```json
{
    "title": "This is a title",
    "author": "John Doe",
    "image": [
        {
        	"url": "http://image1.jpg",
        	"width": 1080,
        	"height": 600
        }
    ],
    "paragraph": [
        "First paragraph"
    ],
    "pullquote": [
        "First pull quote",
        "Second pull quote"
    ],
    "_layout": [
        {
            "type": "title",
            "content": "This is a title"
        },
        {
            "type": "paragraph",
            "content": "First paragraph",
            "free": true
        },
        {
            "type": "pullquote",
            "content": "First pull quote",
            "free": true
        },
        {
            "type": "image",
            "content": {
                "url": "http://image1.jpg",
                "width": 1080,
                "height": 600
            },
            "free": true
        },
        {
            "type": "pullquote",
            "content": "Second pull quote",
            "free": true
        },
        {
            "type": "author",
            "content": "John Doe"
        }
    ]
}
```

API was modified to allow fields of type `String` to exist as arrays of Strings, so they can store multiple blocks. When this happens, validation rules defined in the field's `validation` property are executed against the concatenation of all blocks — e.g. a field containing `["hello", "world"]` with `{minLength: 10}` will pass validation.

I've also added validation to layout maps themselves, so a response will contain an error if the layout map isn't properly formatted or if any of the constraints isn't met.

---

I'm happy to add tests to this if everyone is happy with the implementation.

@jimlambie @josephdenne @mingard let me know your thoughts.

Thanks! 👋 