### PR TITLE
Add support for advanced regex and DateTime queries

### DIFF
--- a/dadi/lib/controller/index.js
+++ b/dadi/lib/controller/index.js
@@ -171,6 +171,10 @@ Controller.prototype.prepareQuery = function(req) {
     _.each(Object.keys(query), function (key) {
       if (!this.keyValidForSchema(key)) {
         delete query[key];
+      } else {
+        var fieldType = this.model.schema[key].type;
+
+        help.transformQuery(query[key], fieldType);
       }
     }, this);
   }

--- a/dadi/lib/controller/index.js
+++ b/dadi/lib/controller/index.js
@@ -172,9 +172,11 @@ Controller.prototype.prepareQuery = function(req) {
       if (!this.keyValidForSchema(key)) {
         delete query[key];
       } else {
-        var fieldType = this.model.schema[key].type;
+        if (this.model.schema[key]) {
+          var fieldType = this.model.schema[key].type;
 
-        help.transformQuery(query[key], fieldType);
+          help.transformQuery(query[key], fieldType);
+        }
       }
     }, this);
   }

--- a/dadi/lib/help.js
+++ b/dadi/lib/help.js
@@ -79,7 +79,6 @@ module.exports.parseQuery = function (queryStr) {
 // Transforms strings from a query object into more appropriate types, based
 // on the field type
 module.exports.transformQuery = function (obj, type) {
-  var self = this;
   var transformFunction;
 
   switch (type) {
@@ -113,13 +112,13 @@ module.exports.transformQuery = function (obj, type) {
       return obj;
   }
 
-  Object.keys(obj).forEach(function (key) {
+  Object.keys(obj).forEach((function (key) {
     if (typeof obj[key] === 'object') {
-      self.transformQuery(obj[key], type);
+      this.transformQuery(obj[key], type);
     } else if (typeof obj[key] === 'string') {
       obj[key] = transformFunction(obj[key]);
     }
-  });
+  }).bind(this));
 };
 
 module.exports.regExpEscape = function(str) {

--- a/dadi/lib/help.js
+++ b/dadi/lib/help.js
@@ -105,6 +105,8 @@ module.exports.transformQuery = function (obj, type) {
           } catch (e) {
             return obj;
           }
+        } else {
+          return obj;
         }
       });
 

--- a/dadi/lib/help.js
+++ b/dadi/lib/help.js
@@ -8,6 +8,7 @@ var _ = require('underscore');
 var cache = require(__dirname + '/cache');
 var config = require(__dirname + '/../../config');
 var log = require(__dirname + '/log');
+var moment = require('moment');
 
 var self = this;
 
@@ -74,6 +75,52 @@ module.exports.parseQuery = function (queryStr) {
   if (typeof ret !== 'object' || ret === null) ret = {};
   return ret;
 }
+
+// Transforms strings from a query object into more appropriate types, based
+// on the field type
+module.exports.transformQuery = function (obj, type) {
+  var self = this;
+  var transformFunction;
+
+  switch (type) {
+    case 'DateTime':
+      transformFunction = (function (obj) {
+        var parsedDate = new moment(obj);
+
+        if (!parsedDate.isValid()) return obj;
+
+        return parsedDate.toDate();
+      });
+
+      break;
+
+    case 'String':
+      transformFunction = (function (obj) {
+        if ((obj.charAt(0) === '/') && (obj.charAt(obj.length - 1) === '/')) {
+          try {
+            var regex = new RegExp(obj.substring(1).slice(0, -1));
+
+            return regex;
+          } catch (e) {
+            return obj;
+          }
+        }
+      });
+
+      break;
+
+    default:
+      return obj;
+  }
+
+  Object.keys(obj).forEach(function (key) {
+    if (typeof obj[key] === 'object') {
+      self.transformQuery(obj[key], type);
+    } else if (typeof obj[key] === 'string') {
+      obj[key] = transformFunction(obj[key]);
+    }
+  });
+};
 
 module.exports.regExpEscape = function(str) {
   return str.replace(/([.?*+^$[\]\\(){}|-])/g, "\\$1");

--- a/dadi/lib/help.js
+++ b/dadi/lib/help.js
@@ -95,9 +95,11 @@ module.exports.transformQuery = function (obj, type) {
 
     case 'String':
       transformFunction = (function (obj) {
-        if ((obj.charAt(0) === '/') && (obj.charAt(obj.length - 1) === '/')) {
+        var regexParts = obj.match(/\/([^\/]*)\/([i]{0,1})$/);
+
+        if (regexParts) {
           try {
-            var regex = new RegExp(obj.substring(1).slice(0, -1));
+            var regex = new RegExp(regexParts[1], regexParts[2]);
 
             return regex;
           } catch (e) {

--- a/dadi/lib/help.js
+++ b/dadi/lib/help.js
@@ -115,7 +115,7 @@ module.exports.transformQuery = function (obj, type) {
   }
 
   Object.keys(obj).forEach((function (key) {
-    if (typeof obj[key] === 'object') {
+    if ((typeof obj[key] === 'object') && (obj[key] !== null)) {
       this.transformQuery(obj[key], type);
     } else if (typeof obj[key] === 'string') {
       obj[key] = transformFunction(obj[key]);

--- a/dadi/lib/model/index.js
+++ b/dadi/lib/model/index.js
@@ -306,7 +306,7 @@ Model.prototype.convertObjectIdsForSave = function (schema, obj) {
 
 Model.prototype.convertDateTimeForSave = function (schema, obj) {
   Object.keys(schema)
-  .filter(function (key) { return schema[key].type === 'DateTime' })
+  .filter(function (key) { return ((schema[key].type === 'DateTime') && (obj[key] !== null)) })
   .forEach(function (key) {
     obj[key] = new Date(moment(obj[key]).toISOString())
   })

--- a/test/acceptance/fields/reference.js
+++ b/test/acceptance/fields/reference.js
@@ -167,7 +167,7 @@ describe('Reference Field', function () {
         .end(function (err, res) {
           if (err) return done(err);
 
-          console.log(res.body)
+          //console.log(res.body)
 
           should.exist(res.body.results)
           var bookResult = res.body.results[0]

--- a/test/unit/helpTest.js
+++ b/test/unit/helpTest.js
@@ -3,176 +3,234 @@ var sinon = require('sinon');
 var help = require(__dirname + '/../../dadi/lib/help');
 
 describe('Help', function (done) {
-    describe('validateCollectionSchema', function() {
-        it('should inform of missing sections', function (done) {
-            var schema = {
+  describe('validateCollectionSchema', function() {
+    it('should inform of missing sections', function (done) {
+      var schema = {
+      }
 
-                }
-;
-            var val = help.validateCollectionSchema(schema);
-            val.success.should.be.false;
-            val.errors.length.should.equal(2);
-            val.errors[0].section.should.equal('fields');
-            val.errors[0].message.should.startWith('must be provided at least once');
+      var val = help.validateCollectionSchema(schema);
+      val.success.should.be.false;
+      val.errors.length.should.equal(2);
+      val.errors[0].section.should.equal('fields');
+      val.errors[0].message.should.startWith('must be provided at least once');
 
-            done();
-        });
-
-        it('should inform of missing settings', function (done) {
-            var schema = {
-                   fields:{
-                        "field1": {
-                            "type": "String",
-                            "label": "Title",
-                            "comments": "The title of the entry",
-                            "placement": "Main content",
-                            "validation": {},
-                            "required": false,
-                            "message": "",
-                            "display": {
-                                "index": true,
-                                "edit": true
-                            }
-                        }
-                   },
-                   settings:{cache:true}
-            };
-
-            var val = help.validateCollectionSchema(schema);
-            val.success.should.be.false;
-            val.errors[0].setting.should.equal('authenticate');
-            val.errors[0].message.should.equal('must be provided');
-
-            done();
-        });
-
-        it('should inform that minimum number of fields not supplied', function (done) {
-            var schema = {
-                   fields:{},
-                   settings:{cache:true,authenticate:true,callback:null,defaultFilters:null,fieldLimiters:null,count:10,sortOrder:1}
-                }
-;
-            var val = help.validateCollectionSchema(schema);
-            val.success.should.be.false;
-            val.errors[0].section.should.equal('fields');
-            val.errors[0].message.should.equal('must include at least one field');
-
-            done();
-        });
-
-        it('should allow field collections within primary `fields` object', function (done) {
-            var schema = {
-            "tab1": {
-                "fields": {
-                    "tab1Field1": {
-                        "type": "String",
-                        "label": "Title",
-                        "comments": "The title of the entry",
-                        "placement": "Main content",
-                        "validation": {},
-                        "required": false,
-                        "message": "",
-                        "display": {
-                            "index": true,
-                            "edit": true
-                        }
-                    }
-                }
-            },
-            "tab2": {
-                "fields": {
-                    "tab2Field1": {
-                        "type": "String"
-                    }
-                }
-            },
-            "settings":{cache:true,authenticate:true,callback:null,defaultFilters:null,fieldLimiters:null,count:10,sortOrder:1}
-            };
-
-            var val = help.validateCollectionSchema(schema);
-            val.success.should.be.true;
-
-            done();
-        });
+      done();
     });
 
-    describe('parseQuery', function () {
-        it('should export method', function (done) {
-            help.parseQuery.should.be.Function;
-            done();
-        });
-
-        it('should return correct JSON object for valid querystring', function (done) {
-            var querystring = '{ "cap_id": 2337,"year":2224,"plate":4 }';
-            var query = help.parseQuery(querystring);
-
-            var k = "", v = "";
-            for(var key in query) {
-                if(query.hasOwnProperty(key) && key == 'plate') {
-                    v = query[key];
-                    k = key;
-                    break;
-                }
+    it('should inform of missing settings', function (done) {
+      var schema = {
+           fields: {
+            "field1": {
+              "type": "String",
+              "label": "Title",
+              "comments": "The title of the entry",
+              "placement": "Main content",
+              "validation": {},
+              "required": false,
+              "message": "",
+              "display": {
+                "index": true,
+                "edit": true
+              }
             }
+           },
+           settings:{cache:true}
+      };
 
-            v.should.equal(4);
+      var val = help.validateCollectionSchema(schema);
+      val.success.should.be.false;
+      val.errors[0].setting.should.equal('authenticate');
+      val.errors[0].message.should.equal('must be provided');
 
-            done();
-        });
-
-        it('should return empty JSON object for invalid querystring', function (done) {
-            var querystring = '{ "cap_id: 2337,"year":2224,"plate":4 }';
-            var query = help.parseQuery(querystring);
-
-            var k = "", v = "";
-            for(var key in query) {
-                if(query.hasOwnProperty(key)) {
-                    v = query[key];
-                    k = key;
-                    break;
-                }
-            }
-
-            k.should.equal("");
-            v.should.equal("");
-
-            done();
-        });
-
-        it('should do nothing for querystring with leading zeroes', function (done) {
-            var querystring = '{ "title": "My 007 Movie" }';
-            var query = help.parseQuery(querystring);
-
-            var k = "", v = "";
-            for(var key in query) {
-                if(query.hasOwnProperty(key) && key == 'title') {
-                    v = query[key];
-                    k = key;
-                    break;
-                }
-            }
-
-            v.should.equal("My 007 Movie");
-
-            done();
-        });
-
-        // it('should return correct JSON object for querystring with leading zeroes', function (done) {
-        //     var querystring = '{ "cap_id": 2337,"year":2224,"plate":04 }';
-        //     var query = help.parseQuery(querystring);
-
-        //     var k = "", v = "";
-        //     for(var key in query) {
-        //         if(query.hasOwnProperty(key) && key == 'plate') {
-        //             v = query[key];
-        //             k = key;
-        //             break;
-        //         }
-        //     }
-
-        //     v.should.equal(4);
-
-        //     done();
-        // });
+      done();
     });
-});
+
+    it('should inform that minimum number of fields not supplied', function (done) {
+      var schema = {
+        fields:{},
+        settings:{cache:true,authenticate:true,callback:null,defaultFilters:null,fieldLimiters:null,count:10,sortOrder:1}
+      }
+
+      var val = help.validateCollectionSchema(schema);
+      val.success.should.be.false;
+      val.errors[0].section.should.equal('fields');
+      val.errors[0].message.should.equal('must include at least one field');
+
+      done();
+    });
+
+    it('should allow field collections within primary `fields` object', function (done) {
+      var schema = {
+      "tab1": {
+        "fields": {
+          "tab1Field1": {
+            "type": "String",
+            "label": "Title",
+            "comments": "The title of the entry",
+            "placement": "Main content",
+            "validation": {},
+            "required": false,
+            "message": "",
+            "display": {
+              "index": true,
+              "edit": true
+            }
+          }
+        }
+      },
+      "tab2": {
+        "fields": {
+          "tab2Field1": {
+            "type": "String"
+          }
+        }
+      },
+      "settings":{cache:true,authenticate:true,callback:null,defaultFilters:null,fieldLimiters:null,count:10,sortOrder:1}
+      };
+
+      var val = help.validateCollectionSchema(schema);
+      val.success.should.be.true;
+
+      done();
+    });
+  });
+
+  describe('parseQuery', function () {
+    it('should export method', function (done) {
+      help.parseQuery.should.be.Function;
+      done();
+    });
+
+    it('should return correct JSON object for valid querystring', function (done) {
+      var querystring = '{ "cap_id": 2337,"year":2224,"plate":4 }';
+      var query = help.parseQuery(querystring);
+
+      var k = "", v = "";
+      for(var key in query) {
+        if(query.hasOwnProperty(key) && key == 'plate') {
+          v = query[key];
+          k = key;
+          break;
+        }
+      }
+
+      v.should.equal(4);
+
+      done();
+    });
+
+    it('should return empty JSON object for invalid querystring', function (done) {
+      var querystring = '{ "cap_id: 2337,"year":2224,"plate":4 }';
+      var query = help.parseQuery(querystring);
+
+      var k = "", v = "";
+      for(var key in query) {
+        if(query.hasOwnProperty(key)) {
+          v = query[key];
+          k = key;
+          break;
+        }
+      }
+
+      k.should.equal("");
+      v.should.equal("");
+
+      done();
+    });
+
+    it('should do nothing for querystring with leading zeroes', function (done) {
+      var querystring = '{ "title": "My 007 Movie" }';
+      var query = help.parseQuery(querystring);
+
+      var k = "", v = "";
+      for(var key in query) {
+        if(query.hasOwnProperty(key) && key == 'title') {
+          v = query[key];
+          k = key;
+          break;
+        }
+      }
+
+      v.should.equal("My 007 Movie");
+
+      done();
+    });
+
+    // it('should return correct JSON object for querystring with leading zeroes', function (done) {
+    //   var querystring = '{ "cap_id": 2337,"year":2224,"plate":04 }';
+    //   var query = help.parseQuery(querystring);
+
+    //   var k = "", v = "";
+    //   for(var key in query) {
+    //     if(query.hasOwnProperty(key) && key == 'plate') {
+    //       v = query[key];
+    //       k = key;
+    //       break;
+    //     }
+    //   }
+
+    //   v.should.equal(4);
+
+    //   done();
+    // });
+  })
+
+  describe('transformQuery', function () {
+    it('should export method', function (done) {
+      help.transformQuery.should.be.Function;
+      done();
+    })
+
+    describe('Other fields', function () {
+      it('should return original query object if it is not a String or DateTime', function (done) {
+        var obj = { 'name': 'John' }
+        help.transformQuery(obj, 'Mixed');
+        obj.should.eql({ 'name': 'John' });
+        done();
+      })
+    })
+
+    describe('DateTime fields', function () {
+      it('should return original query object if it cannot be parsed as a Date', function (done) {
+        var obj = { 'created': 'abcedfg' }
+        help.transformQuery(obj, 'DateTime');
+        obj.should.eql({ 'created': 'abcedfg' });
+        done();
+      })
+
+      it('should return parsed Date if query object can be parsed as a Date', function (done) {
+        var obj = { 'created': '2013-02-08' }
+        help.transformQuery(obj, 'DateTime');
+        (typeof obj.created).should.eql('object')
+        done();
+      })
+    })
+
+    describe('String fields', function () {
+      it('should return original query object if it cannot be parsed as a RegExp', function (done) {
+        var obj = { 'name': 'John' }
+        help.transformQuery(obj, 'String');
+        obj.should.eql({ 'name': 'John' });
+        done();
+      })
+
+      it('should return parsed RegExp if query object can be parsed as a RegExp', function (done) {
+        var obj = { 'name': '/^john/' }
+        help.transformQuery(obj, 'String');
+        (typeof obj.name).should.eql('object')
+        obj.name.should.eql(/^john/)
+        done();
+      })
+
+      it('should return parsed RegExp if query object contains subqueries that can be parsed as a RegExp', function (done) {
+        var obj = { 'name': { '$not': '/^john/'} }
+        help.transformQuery(obj, 'String');
+        (typeof obj.name).should.eql('object')
+
+        obj.name.should.eql({ '$not': /^john/ })
+
+        done();
+      })
+    })
+  })
+})


### PR DESCRIPTION
## Part 1: Advanced regular expression queries

Currently, query filters don't support the full potential of regular expressions provided by MongoDB, as it's limited to `$regex` fields being converted to a `/text/i` expression. This is fine for most use cases, but it doesn't allow for queries like *"value doesn't begin with"* or *"value does not contain"*. The latter would be defined as `{"name":{"$not":/john/i}}`, but API currently ignores the filter because it's not valid JSON. The alternative would be to wrap the regex in quotes, but then MongoDB would treat it as a normal string.

This PR adds a `transformQuery` function that cycles through the filters and transforms them, based on certain conditions, to the format required by MongoDB. When it finds a string that can represent a regular expression (starting and ending with a `/`, with an optional `i` flag), it transforms it into a `RegExp` object.

So the above query would look like:

```
// Documents where `name` doesn't contain `john`
/users?filter={"name":{"$not":"/john/i"}}
```

## Part 2: DateTime queries

Similarly to the problem above, MongoDB can only compare `DateTime` objects if the query is in a JS `Date` object. Currently, they're being sent as strings. `transformQuery` now looks for queries on `DateTime` fields and converts them appropriately. Because it's using [Moment.js](http://momentjs.com/), any valid date format can be used in a query, not just ISO-8601 format.

This means that a query to find documents where `dateOfBirth` is later than a certain date, we can do:

```
/users?filter={"dateOfBirth": {"$gt": "2016-05-16"}}
/users?filter={"dateOfBirth": {"$gt": "2013-02-08 09:30:26"}}
```

---

This will allow us to implement advanced filters on Publish, using API-wrapper.

@jimlambie @josephdenne @mingard thoughts?