### PR TITLE
Teensy tiny change to make API work on 6.x.x

### DIFF
--- a/dadi/lib/controller/index.js
+++ b/dadi/lib/controller/index.js
@@ -117,7 +117,7 @@ Controller.prototype.prepareQueryOptions = function(options) {
   }
 
   // compose / reference fields
-  if (options.hasOwnProperty('compose')) {
+  if (options.compose) {
       queryOptions.compose = options.compose === 'true';
   }
 


### PR DESCRIPTION
### Does this resolve an issue?
API not correctly running on Node 6.x.x

### Description of changes proposed in this pull request
Removes .hasOwnProperty() check since qs no longer inherits from Object and instead uses a direct existence check

### Who should review this pull request?
@jimlambie 

### Testing
1. Install Node 6.x.x
2. Run API
3. Run Test Suite

