### PR TITLE
Refix of hook paths as per PR #81

### DIFF
--- a/dadi/lib/model/hook.js
+++ b/dadi/lib/model/hook.js
@@ -73,7 +73,7 @@ Hook.prototype.apply = function () {
 };
 
 Hook.prototype.load = function () {
-  return require(config.get('paths.hooks') + '/' + this.name);
+  return require(require('path').resolve(config.get('paths.hooks')) + '/' + this.name);
 }
 
 module.exports = function (data, type) {


### PR DESCRIPTION
For some reason this fix didn't make it out of 1.7.0 into master