### PR TITLE
feat: cluster support

### DIFF
--- a/config.js
+++ b/config.js
@@ -264,6 +264,11 @@ var conf = convict({
     env: "NODE_ENV",
     arg: "node_env"
   },
+  cluster: {
+    doc: "If true, API runs in cluster mode, starting a worker for each CPU core",
+    format: Boolean,
+    default: false
+  },
   cors: {
     doc: "If true, responses will include headers for cross-domain resource sharing",
     format: Boolean,

--- a/main.js
+++ b/main.js
@@ -1,5 +1,104 @@
-module.exports       = app = require(__dirname + '/index.js');
+var chokidar = require('chokidar')
+var cluster = require('cluster')
+var config = require('./config')
+var fs = require('fs')
+var path = require('path')
+
+var log = require(__dirname + '/dadi/lib/log.js')
+
+//module.exports       = app = require(__dirname + '/index.js');
 module.exports.Config      = require(__dirname + '/config');
 module.exports.Connection  = require(__dirname + '/dadi/lib/model/connection');
 module.exports.Model       = require(__dirname + '/dadi/lib/model/');
 module.exports.Log         = require(__dirname + '/dadi/lib/log.js');
+
+require('console-stamp')(console, 'yyyy-mm-dd HH:MM:ss.l')
+
+if (config.get('cluster')) {
+
+  if (cluster.isMaster) {
+    var numWorkers = require('os').cpus().length
+    log.info('Starting DADI API in cluster mode, using ' + numWorkers + ' workers.')
+    log.info('Master cluster setting up ' + numWorkers + ' workers...')
+
+    // Start new workers
+    for(var i = 0; i < numWorkers; i++) {
+      cluster.fork()
+    }
+
+    // New worker alive
+    cluster.on('online', function(worker) {
+      log.info('Worker ' + worker.process.pid + ' is online')
+    })
+
+    // Handle a thread exit, start a new worker
+    cluster.on('exit', function(worker, code, signal) {
+      log.info('Worker ' + worker.process.pid + ' died with code: ' + code + ', and signal: ' + signal)
+      log.info('Starting a new worker')
+
+      cluster.fork();
+    })
+
+    // Watch the current directory for a "restart.web" file
+    var watcher = chokidar.watch(process.cwd(), {
+      depth: 0,
+      ignored: /[\/\\]\./,
+      ignoreInitial: true
+    })
+
+    watcher.on('add', function(filePath) {
+      if (path.basename(filePath) === 'restart.api') {
+        log.info('Shutdown requested')
+        fs.unlinkSync(filePath)
+        restartWorkers()
+      }
+    })
+  }
+  else {
+    // Start Workers
+    var app = require(__dirname + '/index.js')
+
+    app.start(function() {
+      log.info('Process ' + process.pid + ' is listening for incoming requests')
+
+      process.on('message', function(message) {
+        if (message.type === 'shutdown') {
+          log.info('Process ' + process.pid + ' is shutting down...')
+
+          process.exit(0)
+        }
+      })
+    })
+  }
+} else {
+  // Single thread start
+  log.info('Starting DADI API in single thread mode.')
+
+  var app = require(__dirname + '/index.js')
+  app.start(function() {
+    log.info('Process ' + process.pid + ' is listening for incoming requests')
+  })
+}
+
+function restartWorkers() {
+  var wid, workerIds = []
+
+  for(wid in cluster.workers) {
+    workerIds.push(wid)
+  }
+
+  workerIds.forEach(function(wid) {
+    if (cluster.workers[wid]) {
+      cluster.workers[wid].send({
+        type: 'shutdown',
+        from: 'master'
+      })
+
+      setTimeout(function() {
+        if(cluster.workers[wid]) {
+          cluster.workers[wid].kill('SIGKILL')
+        }
+      }, 5000)
+    }
+  })
+}

--- a/package.json
+++ b/package.json
@@ -6,15 +6,16 @@
     "init": "validate-commit-msg",
     "test": "env NODE_ENV=test ./node_modules/.bin/istanbul cover -x **/workspace/** --report cobertura --report text --report html --report lcov ./node_modules/.bin/_mocha test",
     "posttest": "./scripts/coverage.js",
-    "start": "node server.js --node_env=development"
+    "start": "node main.js --node_env=development"
   },
   "dependencies": {
     "@dadi/status": "git+https://git@github.com/dadi/status.git",
     "async": "^1.4.2",
     "body-parser": "~1.6.5",
     "bunyan": "^1.5.1",
+    "chokidar": "^1.5.2",
     "colors": "^1.1.2",
-    "console-stamp": "0.2.0",
+    "console-stamp": "^0.2.0",
     "convict": "1.0.1",
     "function-rate-limit": "^1.0.1",
     "latest-version": "~2.0.0",

--- a/server.js
+++ b/server.js
@@ -1,2 +1,0 @@
-var app = require(__dirname + '/index.js');
-app.start(function() {});


### PR DESCRIPTION
This PR adds support for running API in cluster mode. 

1. Add to config: `"cluster": true`
2. To restart workers without restarting the whole app, run `touch restart.api` from the app directory

Close #84 