### PR TITLE
hooks endpoint

### DIFF
--- a/dadi/lib/help.js
+++ b/dadi/lib/help.js
@@ -61,6 +61,24 @@ module.exports.sendBackJSONP = function (callbackName, res, next) {
   }
 }
 
+// helper that sends text response
+module.exports.sendBackText = function (successCode, res, next) {
+  return function (err, results) {
+    if (err) return next(err)
+
+    var resBody = results
+
+    res.setHeader('Server', config.get('server.name'))
+
+    res.setHeader('content-type', 'application/text')
+    res.setHeader('content-length', Buffer.byteLength(resBody))
+
+    res.statusCode = successCode
+
+    res.end(resBody)
+  }
+}
+
 // function to wrap try - catch for JSON.parse to mitigate pref losses
 module.exports.parseQuery = function (queryStr) {
   var ret;

--- a/workspace/hooks/slugify.js
+++ b/workspace/hooks/slugify.js
@@ -1,4 +1,10 @@
-// Example hook: Creates a URL-friendly version (slug) of a field
+/**
+ * Example hook: Creates a URL-friendly version (slug) of a field
+ *
+ * @param {string} `input` The string to slugify
+ * @returns {string} The slugged version of the input
+ * @api public
+ */
 
 function slugify(text) {
 	return text.toString().toLowerCase()


### PR DESCRIPTION
Add endpoints for retrieving loaded hooks

`/api/hooks`
`/api/hooks/:hook/config`

Requires sensible documentation to be added to the top of a hook file:

```
/**
 * Example hook: Creates a URL-friendly version (slug) of a field
 *
 * @param {string} `input` The string to slugify
 * @returns {string} The slugged version of the input
 * @api public
 */
```

Close #78 
