### PR TITLE
allow queries for null values

### DIFF
--- a/dadi/lib/help.js
+++ b/dadi/lib/help.js
@@ -134,13 +134,15 @@ module.exports.transformQuery = function (obj, type) {
       return obj;
   }
 
-  Object.keys(obj).forEach((function (key) {
-    if ((typeof obj[key] === 'object') && (obj[key] !== null)) {
-      this.transformQuery(obj[key], type);
-    } else if (typeof obj[key] === 'string') {
-      obj[key] = transformFunction(obj[key]);
-    }
-  }).bind(this));
+  if (obj) {
+    Object.keys(obj).forEach((function (key) {
+      if ((typeof obj[key] === 'object') && (obj[key] !== null)) {
+        this.transformQuery(obj[key], type);
+      } else if (typeof obj[key] === 'string') {
+        obj[key] = transformFunction(obj[key]);
+      }
+    }).bind(this));
+  }
 };
 
 module.exports.regExpEscape = function(str) {

--- a/test/unit/controller.js
+++ b/test/unit/controller.js
@@ -75,6 +75,47 @@ describe('Controller', function (done) {
                 done();
             });
 
+            it('should allow querying for "null"', function (done) {
+                var mod = model('testModel', help.getModelSchema());
+                var stub = sinon.stub(mod, 'find');
+
+                var req = {
+                    url: '/foo/bar?filter={"fieldName": null}'
+                };
+
+                controller(mod).get(req);
+                stub.callCount.should.equal(1);
+                var findArgs = stub.returnsArg(0).args[0][0];
+                findArgs.hasOwnProperty('fieldName').should.eql(true);
+                stub.restore();
+                done();
+            });
+
+            it('should allow querying for "null" and other fields', function (done) {
+                var schema = help.getModelSchema()
+                schema.field2 = {
+                    "type": "String",
+                    "label": "Title",
+                    "required": false
+                }
+
+                var mod = model('testModel', schema);
+                var stub = sinon.stub(mod, 'find');
+
+                var req = {
+                    url: '/foo/bar?filter={"fieldName": null, "field2": "xx"}'
+                };
+
+                controller(mod).get(req);
+                stub.callCount.should.equal(1);
+                var findArgs = stub.returnsArg(0).args[0][0];
+
+                findArgs.hasOwnProperty('fieldName').should.eql(true);
+                findArgs.hasOwnProperty('field2').should.eql(true);
+                stub.restore();
+                done();
+            });
+
             it('should allow Mixed fields to be queried using `unknown` params', function (done) {
                 var schema = help.getModelSchema();
                 schema = _.extend(schema, {

--- a/test/unit/helpTest.js
+++ b/test/unit/helpTest.js
@@ -181,6 +181,15 @@ describe('Help', function (done) {
       done();
     })
 
+    describe('null value query', function () {
+      it('should allow a query for null in String fields', function (done) {
+        var obj = { 'name': null }
+        help.transformQuery(obj, 'String');
+        obj.should.eql({ 'name': null });
+        done();
+      })
+    })
+
     describe('Other fields', function () {
       it('should return original query object if it is not a String or DateTime', function (done) {
         var obj = { 'name': 'John' }


### PR DESCRIPTION
because null is an object, transformQuery
tries to loop over it's keys, so now check
that "obj" is actually defined

Fix #101 
