### PR TITLE
Skip ObjectId defining reference fields

### DIFF
--- a/dadi/lib/model/index.js
+++ b/dadi/lib/model/index.js
@@ -333,7 +333,7 @@ Model.prototype.convertApparentObjectIds = function (query) {
       if (typeof type !== 'undefined' && type === 'Object') {
         // ignore
       }
-      else {
+      else if(type !== 'Reference') { //Don't return Reference fields for conversion
         query[key] = self.convertApparentObjectIds(query[key])
       }
     }


### PR DESCRIPTION
Fixes issue where Reference fields are not searchable with `$in` query