### PR TITLE
Updates to hooks

### DIFF
--- a/dadi/lib/model/hook.js
+++ b/dadi/lib/model/hook.js
@@ -40,47 +40,57 @@ Hook.prototype.apply = function () {
   switch (this.type) {
     case 'beforeCreate':
       return this.hook(arguments[0], this.type, {
+        collection: arguments[2],
         options: this.options,
-        req: arguments[2],
+        req: arguments[3],
         schema: arguments[1]
       })
 
     case 'afterCreate':
       return this.hook(arguments[0], this.type, {
-        options: this.options
+        collection: arguments[2],
+        options: this.options,
+        schema: arguments[1]
       })
 
     case 'afterGet':
       return this.hook(arguments[0], this.type, {
+        collection: arguments[2],
         options: this.options,
-        req: arguments[2],
+        req: arguments[3],
         schema: arguments[1]
       })
 
     case 'beforeUpdate':
       return this.hook(arguments[0], this.type, {
+        collection: arguments[3],
         options: this.options,
-        req: arguments[3],
+        req: arguments[4],
         schema: arguments[2],
         updatedDocs: arguments[1]
       })
 
     case 'afterUpdate':
       return this.hook(arguments[0], this.type, {
-        options: this.options
+        collection: arguments[2],
+        options: this.options,
+        schema: arguments[1]
       })
 
     case 'beforeDelete':
       return this.hook(arguments[0], this.type, {
+        collection: arguments[3],
         error: arguments[1],
         options: this.options,
-        req: arguments[3],
+        req: arguments[4],
         schema: arguments[2]
       })
 
     case 'afterDelete':
       return this.hook(arguments[0], this.type, {
-        options: this.options
+        collection: arguments[2],
+        options: this.options,
+        schema: arguments[1]
       })
   }
 

--- a/dadi/lib/model/index.js
+++ b/dadi/lib/model/index.js
@@ -172,7 +172,7 @@ Model.prototype.create = function (obj, internals, done, req) {
         async.reduce(this.settings.hooks.beforeCreate, doc, (current, hookConfig, callback) => {
           var hook = new Hook(hookConfig, 'beforeCreate')
 
-          Promise.resolve(hook.apply(current, this.schema, req)).then((newDoc) => {
+          Promise.resolve(hook.apply(current, this.schema, this.name, req)).then((newDoc) => {
             callback((newDoc === null) ? {} : null, newDoc)
           }).catch((err) => {
             callback(err)
@@ -213,7 +213,7 @@ Model.prototype.create = function (obj, internals, done, req) {
           this.settings.hooks.afterCreate.forEach((hookConfig, index) => {
             var hook = new Hook(this.settings.hooks.afterCreate[index], 'afterCreate')
 
-            return hook.apply(doc)
+            return hook.apply(doc, this.schema, this.name)
           })
         })
       }
@@ -572,12 +572,17 @@ Model.prototype.find = function (query, options, done) {
  * @api public
  */
 Model.prototype.get = function (query, options, done, req) {
+  if (typeof options === 'function') {
+    done = options
+    options = {}
+  }
+
   this.find(query, options, (err, results) => {
     if (this.settings.hooks && this.settings.hooks.afterGet) {
       async.reduce(this.settings.hooks.afterGet, results, (current, hookConfig, callback) => {
         var hook = new Hook(hookConfig, 'afterGet')
 
-        Promise.resolve(hook.apply(current, this.schema, req)).then((newResults) => {
+        Promise.resolve(hook.apply(current, this.schema, this.name, req)).then((newResults) => {
           callback((newResults === null) ? {} : null, newResults)
         }).catch((err) => {
           callback(err)
@@ -742,7 +747,7 @@ Model.prototype.update = function (query, update, internals, done, req) {
               this.settings.hooks.afterUpdate.forEach((hookConfig, index) => {
                 var hook = new Hook(this.settings.hooks.afterUpdate[index], 'afterUpdate')
 
-                return hook.apply(docs)
+                return hook.apply(docs, this.schema, this.name)
               })
             }
           }
@@ -784,7 +789,7 @@ Model.prototype.update = function (query, update, internals, done, req) {
         async.reduce(this.settings.hooks.beforeUpdate, update, (current, hookConfig, callback) => {
           var hook = new Hook(hookConfig, 'beforeUpdate')
 
-          Promise.resolve(hook.apply(current, updatedDocs, this.schema, req)).then((newUpdate) => {
+          Promise.resolve(hook.apply(current, updatedDocs, this.schema, this.name, req)).then((newUpdate) => {
             callback((newUpdate === null) ? {} : null, newUpdate)
           }).catch((err) => {
             callback(err)
@@ -835,7 +840,7 @@ Model.prototype.delete = function (query, done, req) {
         var hook = new Hook(hookConfig, 'beforeDelete')
         var hookError = {}
 
-        Promise.resolve(hook.apply(current, hookError, this.schema, req)).then((newQuery) => {
+        Promise.resolve(hook.apply(current, hookError, this.schema, this.name, req)).then((newQuery) => {
           callback((newQuery === null) ? {} : null, newQuery)
         }).catch((err) => {
           callback(err)
@@ -860,7 +865,7 @@ Model.prototype.delete = function (query, done, req) {
           this.settings.hooks.afterDelete.forEach((hookConfig, index) => {
             var hook = new Hook(this.settings.hooks.afterDelete[index], 'afterDelete')
 
-            return hook.apply(query)
+            return hook.apply(query, this.schema, this.name)
           })
         }
       }

--- a/test/acceptance/workspace/hooks/slugify.js
+++ b/test/acceptance/workspace/hooks/slugify.js
@@ -1,0 +1,24 @@
+/**
+ * Example hook: Creates a URL-friendly version (slug) of a field
+ *
+ * @param {string} `input` The string to slugify
+ * @returns {string} The slugged version of the input
+ * @api public
+ */
+
+function slugify(text) {
+	return text.toString().toLowerCase()
+			.replace(/\s+/g, '-')
+			.replace(/[^\w\-]+/g, '')
+			.replace(/\-\-+/g, '-')
+			.replace(/^-+/, '')
+			.replace(/-+$/, '');
+}
+
+module.exports = function (obj, type, data) {
+	// We use the options object to know what field to use as the source
+	// and what field to populate with the slug
+	obj[data.options.to] = slugify(obj[data.options.from]);
+
+	return obj;
+};

--- a/test/unit/model/hooks.js
+++ b/test/unit/model/hooks.js
@@ -62,6 +62,13 @@ logHook += '  return obj;\n'
 logHook += '}\n'
 var logFunction = eval(logHook)
 
+var hijackNameHook = ''
+hijackNameHook += 'module.exports = function (obj, type, data) { \n'
+hijackNameHook += '  obj.results.forEach(function (doc) { doc.name = "Modified by hook" })\n'
+hijackNameHook += '  return obj;\n'
+hijackNameHook += '}\n'
+var hijackFunction = eval(hijackNameHook)
+
 describe('Hook', function () {
   it('should export a constructor', function (done) {
     hook.should.be.Function
@@ -146,6 +153,55 @@ describe('Hook', function () {
 
   describe('`beforeCreate` hook', function () {
     beforeEach(help.cleanUpDB)
+
+    it('should receive collection name and schema', function (done) {
+      var conn = connection()
+      var schema = help.getModelSchema()
+      schema.title = {
+        type: 'String',
+        required: false
+      }
+
+      schema.slug = {
+        type: 'String',
+        required: false
+      }
+
+      var settings = {
+        storeRevisions: false,
+        hooks: {
+          beforeCreate: [{
+            hook: 'slug',
+            options: {
+              from: 'title',
+              to: 'slug'
+            }
+          }]
+        }
+      }
+
+      var inspectFunction = function (obj, type, data) {
+        JSON.stringify(data.schema).should.eql(JSON.stringify(schema))
+        data.collection.should.eql('testModelName')
+      }
+
+      sinon.stub(hook.Hook.prototype, 'load').returns(inspectFunction)
+
+      var mod = model('testModelName', schema, conn, settings)
+
+      mod.create({fieldName: 'foo', title: 'Article One', slug: ''}, function (err, result) {
+        if (err) return done(err)
+
+        hook.Hook.prototype.load.restore()
+
+        // find the obj we just created
+        mod.find({fieldName: 'foo'}, function (err, doc) {
+          if (err) return done(err)
+          
+          done()
+        })
+      })
+    })
 
     it('should modify single documents before create', function (done) {
       var conn = connection()
@@ -305,6 +361,55 @@ describe('Hook', function () {
   describe('`afterCreate` hook', function () {
     beforeEach(help.cleanUpDB)
 
+    it('should receive collection name and schema', function (done) {
+      var conn = connection()
+      var schema = help.getModelSchema()
+      schema.title = {
+        type: 'String',
+        required: false
+      }
+
+      schema.slug = {
+        type: 'String',
+        required: false
+      }
+
+      var settings = {
+        storeRevisions: false,
+        hooks: {
+          beforeCreate: [{
+            hook: 'slug',
+            options: {
+              from: 'title',
+              to: 'slug'
+            }
+          }]
+        }
+      }
+
+      var inspectFunction = function (obj, type, data) {
+        JSON.stringify(data.schema).should.eql(JSON.stringify(schema))
+        data.collection.should.eql('testModelName')
+      }
+
+      sinon.stub(hook.Hook.prototype, 'load').returns(inspectFunction)
+
+      var mod = model('testModelName', schema, conn, settings)
+
+      mod.create({fieldName: 'foo', title: 'Article One', slug: ''}, function (err, result) {
+        if (err) return done(err)
+
+        hook.Hook.prototype.load.restore()
+
+        // find the obj we just created
+        mod.find({fieldName: 'foo'}, function (err, doc) {
+          if (err) return done(err)
+          
+          done()
+        })
+      })
+    })    
+
     it('should modify single documents after create', function (done) {
       var conn = connection()
       var schema = help.getModelSchema()
@@ -424,6 +529,55 @@ describe('Hook', function () {
   describe('`beforeUpdate` hook', function () {
     beforeEach(help.cleanUpDB)
 
+    it('should receive collection name and schema', function (done) {
+      var conn = connection()
+      var schema = help.getModelSchema()
+      schema.title = {
+        type: 'String',
+        required: false
+      }
+
+      schema.slug = {
+        type: 'String',
+        required: false
+      }
+
+      var settings = {
+        storeRevisions: false,
+        hooks: {
+          beforeCreate: [{
+            hook: 'slug',
+            options: {
+              from: 'title',
+              to: 'slug'
+            }
+          }]
+        }
+      }
+
+      var inspectFunction = function (obj, type, data) {
+        JSON.stringify(data.schema).should.eql(JSON.stringify(schema))
+        data.collection.should.eql('testModelName')
+      }
+
+      sinon.stub(hook.Hook.prototype, 'load').returns(inspectFunction)
+
+      var mod = model('testModelName', schema, conn, settings)
+
+      mod.create({fieldName: 'foo', title: 'Article One', slug: ''}, function (err, result) {
+        if (err) return done(err)
+
+        hook.Hook.prototype.load.restore()
+
+        // find the obj we just created
+        mod.find({fieldName: 'foo'}, function (err, doc) {
+          if (err) return done(err)
+          
+          done()
+        })
+      })
+    })    
+
     it('should modify documents before update', function (done) {
       var conn = connection()
       var schema = help.getModelSchema()
@@ -480,6 +634,55 @@ describe('Hook', function () {
 
   describe('`afterUpdate` hook', function () {
     beforeEach(help.cleanUpDB)
+
+    it('should receive collection name and schema', function (done) {
+      var conn = connection()
+      var schema = help.getModelSchema()
+      schema.title = {
+        type: 'String',
+        required: false
+      }
+
+      schema.slug = {
+        type: 'String',
+        required: false
+      }
+
+      var settings = {
+        storeRevisions: false,
+        hooks: {
+          beforeCreate: [{
+            hook: 'slug',
+            options: {
+              from: 'title',
+              to: 'slug'
+            }
+          }]
+        }
+      }
+
+      var inspectFunction = function (obj, type, data) {
+        JSON.stringify(data.schema).should.eql(JSON.stringify(schema))
+        data.collection.should.eql('testModelName')
+      }
+
+      sinon.stub(hook.Hook.prototype, 'load').returns(inspectFunction)
+
+      var mod = model('testModelName', schema, conn, settings)
+
+      mod.create({fieldName: 'foo', title: 'Article One', slug: ''}, function (err, result) {
+        if (err) return done(err)
+
+        hook.Hook.prototype.load.restore()
+
+        // find the obj we just created
+        mod.find({fieldName: 'foo'}, function (err, doc) {
+          if (err) return done(err)
+          
+          done()
+        })
+      })
+    })    
 
     it('should modify documents after create', function (done) {
       var conn = connection()
@@ -543,6 +746,55 @@ describe('Hook', function () {
   describe('`beforeDelete` hook', function () {
     beforeEach(help.cleanUpDB)
 
+    it('should receive collection name and schema', function (done) {
+      var conn = connection()
+      var schema = help.getModelSchema()
+      schema.title = {
+        type: 'String',
+        required: false
+      }
+
+      schema.slug = {
+        type: 'String',
+        required: false
+      }
+
+      var settings = {
+        storeRevisions: false,
+        hooks: {
+          beforeCreate: [{
+            hook: 'slug',
+            options: {
+              from: 'title',
+              to: 'slug'
+            }
+          }]
+        }
+      }
+
+      var inspectFunction = function (obj, type, data) {
+        JSON.stringify(data.schema).should.eql(JSON.stringify(schema))
+        data.collection.should.eql('testModelName')
+      }
+
+      sinon.stub(hook.Hook.prototype, 'load').returns(inspectFunction)
+
+      var mod = model('testModelName', schema, conn, settings)
+
+      mod.create({fieldName: 'foo', title: 'Article One', slug: ''}, function (err, result) {
+        if (err) return done(err)
+
+        hook.Hook.prototype.load.restore()
+
+        // find the obj we just created
+        mod.find({fieldName: 'foo'}, function (err, doc) {
+          if (err) return done(err)
+          
+          done()
+        })
+      })
+    })    
+
     // this one writes to a log file before deleting the document
     // see the logFunction declared at the top of this file
     it('should fire delete hook for documents before delete', function (done) {
@@ -600,6 +852,213 @@ describe('Hook', function () {
               })
             })
           }, 500)
+        })
+      })
+    })
+  })
+
+  describe('`afterDelete` hook', function () {
+    beforeEach(help.cleanUpDB)
+
+    it('should receive collection name and schema', function (done) {
+      var conn = connection()
+      var schema = help.getModelSchema()
+      schema.title = {
+        type: 'String',
+        required: false
+      }
+
+      schema.slug = {
+        type: 'String',
+        required: false
+      }
+
+      var settings = {
+        storeRevisions: false,
+        hooks: {
+          beforeCreate: [{
+            hook: 'slug',
+            options: {
+              from: 'title',
+              to: 'slug'
+            }
+          }]
+        }
+      }
+
+      var inspectFunction = function (obj, type, data) {
+        JSON.stringify(data.schema).should.eql(JSON.stringify(schema))
+        data.collection.should.eql('testModelName')
+      }
+
+      sinon.stub(hook.Hook.prototype, 'load').returns(inspectFunction)
+
+      var mod = model('testModelName', schema, conn, settings)
+
+      mod.create({fieldName: 'foo', title: 'Article One', slug: ''}, function (err, result) {
+        if (err) return done(err)
+
+        hook.Hook.prototype.load.restore()
+
+        // find the obj we just created
+        mod.find({fieldName: 'foo'}, function (err, doc) {
+          if (err) return done(err)
+          
+          done()
+        })
+      })
+    })    
+
+    // this one writes to a log file before deleting the document
+    // see the logFunction declared at the top of this file
+    it('should fire delete hook for documents after delete', function (done) {
+      var conn = connection()
+      var schema = help.getModelSchema()
+      schema.title = {
+        type: 'String',
+        required: false
+      }
+
+      schema.slug = {
+        type: 'String',
+        required: false
+      }
+
+      var settings = {
+        storeRevisions: false,
+        hooks: {
+          afterDelete: [{
+            hook: 'writeToLog',
+            options: {
+              filename: 'testBeforeDeleteHook.log'
+            }
+          }]
+        }
+      }
+
+      sinon.stub(hook.Hook.prototype, 'load').returns(logFunction)
+
+      var mod = model('testModelName', schema, conn, settings)
+
+      mod.create({fieldName: 'foo', title: 'Article One', slug: ''}, function (err, result) {
+        if (err) return done(err)
+
+        var id = result.results[0]._id.toString()
+
+        // delete the obj we just created
+        mod.delete({ _id: id }, function (err, doc) {
+          if (err) return done(err)
+
+          hook.Hook.prototype.load.restore()
+
+          setTimeout(function () {
+            // try to find the obj
+            mod.find({ _id: id }, function (err, doc) {
+              if (err) return done(err)
+
+              var fs = require('fs')
+              var path = require('path')
+              var file = path.resolve(path.join(__dirname, 'testBeforeDeleteHook.log'))
+              fs.stat(file, function (err, stats) {
+                (err === null).should.eql(true)
+                fs.unlinkSync(file)
+                done()
+              })
+            })
+          }, 500)
+        })
+      })
+    })
+  })
+
+  describe('`afterGet` hook', function () {
+    beforeEach(help.cleanUpDB)
+
+    it('should receive collection name and schema', function (done) {
+      var conn = connection()
+      var schema = help.getModelSchema()
+      schema.title = {
+        type: 'String',
+        required: false
+      }
+
+      schema.slug = {
+        type: 'String',
+        required: false
+      }
+
+      var settings = {
+        storeRevisions: false,
+        hooks: {
+          beforeCreate: [{
+            hook: 'slug',
+            options: {
+              from: 'title',
+              to: 'slug'
+            }
+          }]
+        }
+      }
+
+      var inspectFunction = function (obj, type, data) {
+        JSON.stringify(data.schema).should.eql(JSON.stringify(schema))
+        data.collection.should.eql('testModelName')
+      }
+
+      sinon.stub(hook.Hook.prototype, 'load').returns(inspectFunction)
+
+      var mod = model('testModelName', schema, conn, settings)
+
+      mod.create({fieldName: 'foo', title: 'Article One', slug: ''}, function (err, result) {
+        if (err) return done(err)
+
+        hook.Hook.prototype.load.restore()
+
+        // find the obj we just created
+        mod.find({fieldName: 'foo'}, function (err, doc) {
+          if (err) return done(err)
+          
+          done()
+        })
+      })
+    })
+
+    it('should modify documents before responding to a GET', function (done) {
+      var conn = connection()
+      var schema = help.getModelSchema()
+      schema.title = {
+        type: 'String',
+        required: false
+      }
+
+      schema.slug = {
+        type: 'String',
+        required: false
+      }
+
+      var settings = {
+        storeRevisions: false,
+        hooks: {
+          afterGet: ['slug']
+        }
+      }
+
+      sinon.stub(hook.Hook.prototype, 'load').returns(hijackFunction)
+
+      var mod = model('testModelName', schema, conn, settings)
+
+      mod.create({fieldName: 'foo', title: 'Article One', slug: ''}, function (err, result) {
+        if (err) return done(err)
+
+        // find the obj we just created
+        mod.get({fieldName: 'foo'},function (err, doc) {
+          if (err) return done(err)
+
+          hook.Hook.prototype.load.restore()
+
+          doc.results[0].name.should.eql('Modified by hook')
+
+          done()
         })
       })
     })


### PR DESCRIPTION
This PR:

- Adds the collection name to the data object being passed to hooks (closing #112)
- Standardises data being passed to hooks. They now receive:
  - The options object specified in the collection schema (`data.options`)
  - The collection name (`data.collection`)
  - The fields schema (`data.schema`)
  - On `before` hooks, the request (`data.req`)
- Adds unit tests for `afterDelete` and `afterGet` hooks and minor improvements to the others

/cc @jimlambie @mingard 