### PR TITLE
Add support for batch delete

### DIFF
--- a/dadi/lib/controller/index.js
+++ b/dadi/lib/controller/index.js
@@ -263,8 +263,9 @@ Controller.prototype.put = function (req, res, next) {
 }
 
 Controller.prototype.delete = function (req, res, next) {
-    var id = req.params.id;
-    if (!id) return next();
+    var query = req.params.id ? {_id: req.params.id} : req.body.query
+
+    if (!query) return next();
 
     var self = this;
 
@@ -278,7 +279,7 @@ Controller.prototype.delete = function (req, res, next) {
     help.clearCache(pathname, function (err) {
         if (err) return next(err);
 
-        self.model.delete({_id: id}, function (err, results) {
+        self.model.delete(query, function (err, results) {
             if (err) return next(err);
 
             if (config.get('feedback')) {
@@ -286,7 +287,7 @@ Controller.prototype.delete = function (req, res, next) {
                 // send 200 with json message
                 return help.sendBackJSON(200, res, next)(null, {
                     status: 'success',
-                    message: 'Document deleted successfully'
+                    message: 'Documents deleted successfully'
                 });
             }
 

--- a/test/unit/model/index.js
+++ b/test/unit/model/index.js
@@ -686,7 +686,7 @@ describe('Model', function () {
       model('testModelName').delete({fieldName: 'foo'}, done)
     })
 
-    it('should delete a document', function (done) {
+    it('should delete a single document', function (done) {
       var mod = model('testModelName')
       mod.create({fieldName: 'foo'}, function (err, result) {
         if (err) return done(err)
@@ -696,6 +696,29 @@ describe('Model', function () {
           if (err) return done(err)
 
           numAffected.should.equal(1)
+
+          mod.find({}, function (err, result) {
+            if (err) return done(err)
+
+            result['results'].length.should.equal(0)
+            done()
+          })
+        })
+      })
+    })
+
+    it('should delete multiple documents', function (done) {
+      var mod = model('testModelName')
+      mod.create([{fieldName: 'foo'}, {fieldName: 'bar'}, {fieldName: 'baz'}], function (err, result) {
+        if (err) return done(err)
+        result.results[0].fieldName.should.equal('foo')
+        result.results[1].fieldName.should.equal('bar')
+        result.results[2].fieldName.should.equal('baz')
+
+        mod.delete({fieldName: {$in: ['foo', 'bar', 'baz']}}, function (err, numAffected) {
+          if (err) return done(err)
+
+          numAffected.should.equal(3)
 
           mod.find({}, function (err, result) {
             if (err) return done(err)


### PR DESCRIPTION
This PR adds support for batch delete of documents, as per #46. 

It follows the same syntax of batch update, introduced in #48:

```
Method: DELETE

URL: http://my.api/vjoin/testdb/articles

Body: 
{
  "query": {
    "name": {"$in": ["foo", "bar", "baz]}
  }
}
```

Includes unit tests.

/cc @jimlambie @mingard 