### PR TITLE
Add fields param support to history and introduce historyFilters

### DIFF
--- a/dadi/lib/controller/index.js
+++ b/dadi/lib/controller/index.js
@@ -124,6 +124,10 @@ Controller.prototype.prepareQueryOptions = function(options) {
   // history
   if (options.includeHistory) {
       queryOptions.includeHistory = options.includeHistory === 'true';
+
+      if (options.historyFilters) {
+        queryOptions.historyFilters = options.historyFilters
+      }
   }
 
   // sorting

--- a/test/unit/model/index.js
+++ b/test/unit/model/index.js
@@ -421,7 +421,7 @@ describe('Model', function () {
             var doc_id = doc.results[0]._id
             var revision_id = doc.results[0].history[0] // expected history object
 
-            model('testModelName', help.getModelSchema()).revisions(doc_id, function (err, result) {
+            model('testModelName', help.getModelSchema()).revisions(doc_id, {}, function (err, result) {
               if (err) return done(err)
 
               result.should.be.Array


### PR DESCRIPTION
This PR makes `includeHistory` respect the `fields` param, so that documents in history only contain the fields specified. This closes task 3 in #93.

Additionally, it introduces a `historyFilters` URL parameter, to be used in conjunction with `includeHistory`, which adds the option to have a filter specific to the documents in history, with the same syntax as the existing `filter`.

This makes it possible to retrieve only the revisions where name is `Jim`:

```
http://localhost:3000/vjoin/testdb/users/57866216acc4818e048efd36?includeHistory=true&historyFilters={"name":"Jim"}
```

Or, as specified by task 4 in #93, get revisions between two dates:

```
http://localhost:3000/vjoin/testdb/users/57866216acc4818e048efd36?includeHistory=true&historyFilters={"lastModifiedAt":{"$gte":1468424733361,"$lte":1468424737447}}
```

This should then close #93.

/cc @jimlambie @mingard 