### PR TITLE
DateTime Model recognises format field

### DIFF
--- a/dadi/lib/model/index.js
+++ b/dadi/lib/model/index.js
@@ -275,7 +275,12 @@ Model.prototype.convertDateTimeForSave = function (schema, obj) {
   Object.keys(schema)
     .filter(function (key) { return ((schema[key].type === 'DateTime') && (obj[key] !== null)) })
     .forEach(function (key) {
-      obj[key] = new Date(moment(obj[key]).toISOString())
+      switch(schema[key].format) {
+        case 'unix':
+          obj[key] = moment(obj[key]).unix()
+        break;
+        default: obj[key] = new Date(moment(obj[key]).toISOString())
+      }
     })
 
   return obj

--- a/dadi/lib/model/index.js
+++ b/dadi/lib/model/index.js
@@ -277,7 +277,10 @@ Model.prototype.convertDateTimeForSave = function (schema, obj) {
     .forEach(function (key) {
       switch(schema[key].format) {
         case 'unix':
-          obj[key] = moment(obj[key]).unix()
+          //No change
+        break;
+        case 'iso':
+          obj[key] = new Date(moment(obj[key]).toISOString())
         break;
         default: obj[key] = new Date(moment(obj[key]).toISOString())
       }


### PR DESCRIPTION
In some cases we need to store the DateTime as a unix value.
Introduce a field formatting param to compose according to type. Currently only `unix` with fallback to `ISO`