### PR TITLE
Catch undefined DateTime

### DIFF
--- a/dadi/lib/model/index.js
+++ b/dadi/lib/model/index.js
@@ -273,7 +273,7 @@ Model.prototype.convertObjectIdsForSave = function (schema, obj) {
 
 Model.prototype.convertDateTimeForSave = function (schema, obj) {
   Object.keys(schema).filter(function (key) {
-    return ((schema[key].type === 'DateTime') && (obj[key] !== null))
+    return ((schema[key].type === 'DateTime') && (obj[key] !== null) && (!_.isUndefined(obj[key])))
   }).forEach(function (key) {
     switch(schema[key].format) {
       case 'unix':

--- a/dadi/lib/model/index.js
+++ b/dadi/lib/model/index.js
@@ -273,7 +273,7 @@ Model.prototype.convertObjectIdsForSave = function (schema, obj) {
 
 Model.prototype.convertDateTimeForSave = function (schema, obj) {
   Object.keys(schema).filter(function (key) {
-    return ((schema[key].type === 'DateTime') && (obj[key] !== null) && (!_.isUndefined(obj[key])))
+    return schema[key].type === 'DateTime' && obj[key] !== null && !_.isUndefined(obj[key])
   }).forEach(function (key) {
     switch(schema[key].format) {
       case 'unix':


### PR DESCRIPTION
When an undefined DateTime value is passed to the field model index it needs to be filtered out. This change addresses and fixes the issue