### PR TITLE
Add interactive create-client util

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "1.12.1",
   "main": "main.js",
   "scripts": {
-    "create-client": "node utils/create-client.js",
+    "create-client": "cd ../../.. && ./node_modules/@dadi/api/utils/create-client.js",
     "init": "validate-commit-msg",
     "test": "env NODE_ENV=test ./node_modules/.bin/istanbul cover -x **/workspace/** --report cobertura --report text --report html --report lcov ./node_modules/.bin/_mocha test",
     "posttest": "./scripts/coverage.js",

--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "1.12.1",
   "main": "main.js",
   "scripts": {
+    "create-client": "node utils/create-client.js",
     "init": "validate-commit-msg",
     "test": "env NODE_ENV=test ./node_modules/.bin/istanbul cover -x **/workspace/** --report cobertura --report text --report html --report lcov ./node_modules/.bin/_mocha test",
     "posttest": "./scripts/coverage.js",
@@ -14,6 +15,7 @@
     "body-parser": "~1.6.5",
     "bunyan": "^1.5.1",
     "chokidar": "^1.5.2",
+    "cli-prompt": "^0.6.0",
     "colors": "^1.1.2",
     "console-stamp": "^0.2.0",
     "convict": "1.1.1",

--- a/utils/create-client.js
+++ b/utils/create-client.js
@@ -1,19 +1,56 @@
-// Create a client object, enabling access to the api
-var connection = require(__dirname + '/../dadi/lib/model/connection');
-var config = require(__dirname + '/../config');
+const Connection = require(__dirname + '/../dadi/lib/model/connection')
+const config = require(__dirname + '/../config')
 
-var conn = connection(config.get('auth.database'));
-var clientCollectionName = config.get('auth.clientCollection');
+const connection = Connection(config.get('auth.database'))
+const clientCollectionName = config.get('auth.clientCollection')
 
-conn.on('connect', function (db) {
+const prompt = require('cli-prompt')
 
-    // Note: this is for QA testing or example purposes only
-    db.collection(clientCollectionName).insert({
-        clientId: 'testClient',
-        secret: 'superSecret'
-    }, function (err) {
-        if (err) throw err;
+connection.on('connect', db => {
+  console.log()
+  console.log('==================================')
+  console.log(' DADI API Client Record Generator ')
+  console.log('==================================')
+  console.log()
 
-        db.close();
-    });
+  prompt.multi([
+    {
+      label: '-> Client identifier',
+      key: 'clientId',
+      default: 'testClient'
+    },
+    {
+      label: '-> Secret access key',
+      key: 'secret',
+      default: 'secretSquirrel'
+    },
+    {
+      label: '-> Access type (admin, user)',
+      key: 'type',
+      default: 'user'
+    },
+    {
+      label: '(!) Is this ok?',
+      key: 'confirm',
+      type: 'boolean'
+    }
+  ], options => {
+    if (options.confirm) {
+      delete options.confirm
+
+      db.collection(clientCollectionName).insert(options, err => {
+        if (err) throw err
+
+        console.log()
+        console.log('(*) Client created successfully:')
+        console.log()
+        console.log(options)
+        console.log()
+
+        db.close()
+      })
+    } else {
+      db.close()
+    }
+  })
 })

--- a/utils/create-client.js
+++ b/utils/create-client.js
@@ -1,56 +1,71 @@
-const Connection = require(__dirname + '/../dadi/lib/model/connection')
-const config = require(__dirname + '/../config')
+#! /usr/bin/env node
+
+'use strict'
+
+const Connection = require('@dadi/api').Connection
+const config = require('@dadi/api').Config
 
 const connection = Connection(config.get('auth.database'))
 const clientCollectionName = config.get('auth.clientCollection')
 
 const prompt = require('cli-prompt')
 
+let connected = false
+
+// Temporarily restore original console
+delete console.log
+
 connection.on('connect', db => {
-  console.log()
-  console.log('==================================')
-  console.log(' DADI API Client Record Generator ')
-  console.log('==================================')
-  console.log()
+  if (connected) return
 
-  prompt.multi([
-    {
-      label: '-> Client identifier',
-      key: 'clientId',
-      default: 'testClient'
-    },
-    {
-      label: '-> Secret access key',
-      key: 'secret',
-      default: 'secretSquirrel'
-    },
-    {
-      label: '-> Access type (admin, user)',
-      key: 'type',
-      default: 'user'
-    },
-    {
-      label: '(!) Is this ok?',
-      key: 'confirm',
-      type: 'boolean'
-    }
-  ], options => {
-    if (options.confirm) {
-      delete options.confirm
+  connected = true
 
-      db.collection(clientCollectionName).insert(options, err => {
-        if (err) throw err
+  setTimeout(() => {
+    console.log()
+    console.log('==================================')
+    console.log(' DADI API Client Record Generator ')
+    console.log('==================================')
+    console.log()
 
-        console.log()
-        console.log('(*) Client created successfully:')
-        console.log()
-        console.log(options)
-        console.log()
+    prompt.multi([
+      {
+        label: '-> Client identifier',
+        key: 'clientId',
+        default: 'testClient'
+      },
+      {
+        label: '-> Secret access key',
+        key: 'secret',
+        default: 'secretSquirrel'
+      },
+      {
+        label: '-> Access type (admin, user)',
+        key: 'type',
+        default: 'user'
+      },
+      {
+        label: '(!) Is this ok?',
+        key: 'confirm',
+        type: 'boolean'
+      }
+    ], options => {
+      if (options.confirm) {
+        delete options.confirm
 
+        db.collection(clientCollectionName).insert(options, err => {
+          if (err) throw err
+
+          console.log()
+          console.log('(*) Client created successfully:')
+          console.log()
+          console.log(options)
+          console.log()
+
+          db.close()
+        })
+      } else {
         db.close()
-      })
-    } else {
-      db.close()
-    }
-  })
+      }
+    })
+  }, 1000)
 })


### PR DESCRIPTION
This PR changes the `create-client` util to work as a small, interactive CLI tool, allowing users to choose the clientId/secret pair instead of using the default ones. It can be used when bootstrapping a DADI API application, or any time afterwards, to create a new client.

## Usage

When using DADI API from source (e.g. cloning the repository):

```shell
node utils/create-client.js
```

When using DADI API as a NPM module:

```shell
npm explore @dadi/api -- npm run create-client
```

## Example

```
==================================
 DADI API Client Record Generator 
==================================

-> Client identifier: (testClient) myClient
-> Secret access key: (secretSquirrel) mySecret
-> Access type (admin, user): (user) admin
(!) Is this ok?: (y/n) y

(*) Client created successfully:

{ clientId: 'myClient',
  secret: 'mySecret',
  type: 'admin',
  _id: 57d4116c8aa4ab9d83bc6401 }
```

/cc @jimlambie 