### PR TITLE
Allow app to be executed from an external directory

### DIFF
--- a/config.js
+++ b/config.js
@@ -1,5 +1,5 @@
-var convict = require('convict');
-var fs = require('fs');
+var convict = require('convict')
+var fs = require('fs')
 
 // Define a schema
 var conf = convict({
@@ -296,35 +296,35 @@ var conf = convict({
     format: Boolean,
     default: false
   }
-});
+})
 
 // Load environment dependent configuration
-var env = conf.get('env');
-conf.loadFile('./config/config.' + env + '.json');
+var env = conf.get('env')
+conf.loadFile('./config/config.' + env + '.json')
 
 // Perform validation
-conf.validate({strict: false});
+conf.validate({strict: false})
 
 // Load domain-specific configuration
 conf.updateConfigDataForDomain = function(domain) {
-  var domainConfig = './config/' + domain + '.json';
+  var domainConfig = './config/' + domain + '.json'
   try {
-    var stats = fs.statSync(domainConfig);
+    var stats = fs.statSync(domainConfig)
     // no error, file exists
-    conf.loadFile(domainConfig);
-    conf.validate({strict: false});
+    conf.loadFile(domainConfig)
+    conf.validate({strict: false})
   }
   catch(err) {
     if (err.code === 'ENOENT') {
-      //console.log('No domain-specific configuration file: ' + domainConfig);
+      //console.log('No domain-specific configuration file: ' + domainConfig)
     }
     else {
-      console.log(err);
+      console.log(err)
     }
   }
-};
+}
 
-module.exports = conf;
+module.exports = conf
 module.exports.configPath = function() {
-  return './config/config.' + conf.get('env') + '.json';
+  return './config/config.' + conf.get('env') + '.json'
 }

--- a/config.js
+++ b/config.js
@@ -300,7 +300,7 @@ var conf = convict({
 
 // Load environment dependent configuration
 var env = conf.get('env')
-conf.loadFile('./config/config.' + env + '.json')
+conf.loadFile(getConfigPath())
 
 // Perform validation
 conf.validate({strict: false})
@@ -324,7 +324,16 @@ conf.updateConfigDataForDomain = function(domain) {
   }
 }
 
-module.exports = conf
-module.exports.configPath = function() {
-  return './config/config.' + conf.get('env') + '.json'
+function getBasePath() {
+  return path.dirname(path.relative(process.cwd(), process.argv[1]))
 }
+
+function getConfigPath() {
+  var configPath = path.resolve(getBasePath(), 'config', 'config.' + conf.get('env') + '.json')
+
+  return configPath
+}
+
+module.exports = conf;
+module.exports.basePath = getBasePath()
+module.exports.configPath = getConfigPath

--- a/config.js
+++ b/config.js
@@ -1,5 +1,6 @@
 var convict = require('convict')
 var fs = require('fs')
+var path = require('path')
 
 // Define a schema
 var conf = convict({
@@ -325,7 +326,15 @@ conf.updateConfigDataForDomain = function(domain) {
 }
 
 function getBasePath() {
-  return path.dirname(path.relative(process.cwd(), process.argv[1]))
+  var configFilePath = __dirname
+  var callingDirectoryPath = process.cwd()
+
+  // Running from inside the app directory?
+  if (callingDirectoryPath.indexOf(configFilePath) === 0) {
+    return '.'
+  }
+
+  return path.dirname(path.relative(callingDirectoryPath, process.argv[1]))
 }
 
 function getConfigPath() {

--- a/dadi/lib/index.js
+++ b/dadi/lib/index.js
@@ -27,6 +27,7 @@ var help = require(__dirname + '/help');
 var dadiStatus = require('@dadi/status');
 
 var config = require(__dirname + '/../../config');
+var basePath = config.basePath
 var configPath = path.resolve(config.configPath());
 
 if (config.get('env') !== 'test') {
@@ -226,9 +227,9 @@ Server.prototype.loadPaths = function(paths, done) {
   var self = this;
   var options = {};
 
-  options.collectionPath = path.resolve(paths.collections || __dirname + '/../../workspace/collections');
-  options.endpointPath = path.resolve(paths.endpoints || __dirname + '/../../workspace/endpoints');
-  options.hookPath = path.resolve(paths.hooks || __dirname + '/../../workspace/hooks');
+  options.collectionPath = path.resolve(basePath, paths.collections || __dirname + '/../../workspace/collections');
+  options.endpointPath = path.resolve(basePath, paths.endpoints || __dirname + '/../../workspace/endpoints');
+  options.hookPath = path.resolve(basePath, paths.hooks || __dirname + '/../../workspace/hooks');
 
   var idx = 0;
 


### PR DESCRIPTION
At the moment, this works:

```
cd api-directory
node start.js
```

But this doesn't:

```
node api-directory/start.js
```

This can be an issue when running the app as a sub-app (for example [here](https://github.com/eduardoboucas/dadi-container), where API and Web are being called by a parent process from another directory).

This PR is a proposal to address that, adding the concept of a base path to the config loader. This will be empty (or `.`) when the app is loaded from its own directory (or any sub-directory inside it) as per usual, but will be `api-directory/` for the example above. This way, files will be loaded correctly.

@jimlambie Bit of a critical change. All tests are passing and I've tested in any way I could think of, but would love your thoughts and help on this one, if you think it's worth implementing.

Thanks! 🎉 👋 🚶 

P.S. Took the opportunity to remove semi-colons from the config loader file.
