### PR TITLE
Unique indexes

### DIFF
--- a/dadi/lib/help.js
+++ b/dadi/lib/help.js
@@ -250,7 +250,7 @@ module.exports.validateCollectionSchema = function (obj) {
     }
 
     if (!indexSpecified) {
-      response.errors.push(formatError.createApiError('0001', { "field": obj.settings.sort }))
+      response.errors.push(formatError.createApiError('0001', { 'field': obj.settings.sort }))
     }
   }
 

--- a/dadi/lib/index.js
+++ b/dadi/lib/index.js
@@ -381,7 +381,7 @@ Server.prototype.loadConfigApi = function () {
       var err = new Error('Collection schema validation failed')
       err.statusCode = 400
       err.success = validation.success
-      err.errors = JSON.stringify(validation.errors)
+      err.errors = validation.errors
       return next(err)
     }
 

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     "start": "node start.js --node_env=development"
   },
   "dependencies": {
+    "@dadi/format-error": "^1.0.0",
     "@dadi/logger": "latest",
     "@dadi/status": "git+https://git@github.com/dadi/status.git",
     "async": "^1.4.2",

--- a/test/acceptance/app.js
+++ b/test/acceptance/app.js
@@ -2165,6 +2165,33 @@ describe('Application', function () {
           })
       })
 
+      it('should check that sort fields are included in the index schema', function (done) {
+        var client = request(connectionString)
+        var schema = JSON.parse(jsSchemaString)
+        schema.settings.sort = 'newField'
+        var newString = JSON.stringify(schema)
+
+        client
+          .post('/vapicreate/testdb/api-create/config')
+          .send(newString)
+          .set('content-type', 'text/plain')
+          .set('Authorization', 'Bearer ' + bearerToken)
+          .expect(400)
+          .expect('content-type', 'application/json')
+          .end(function (err, res) {
+            if (err) return done(err)
+
+            res.body.should.be.Object
+            res.body.should.not.be.Array
+            should.exist(res.body.errors)
+            res.body.errors.should.be.Array
+
+            res.body.errors[0].title.should.eql('Missing Index Key')
+
+            done()
+          })
+      })
+
       it('should allow creating a new collection endpoint', function (done) {
         var client = request(connectionString)
 

--- a/test/acceptance/hooks.js
+++ b/test/acceptance/hooks.js
@@ -46,7 +46,7 @@ describe('Hooks', function () {
 
 //   if (fs.existsSync(newSchemaPath)) fs.unlinkSync(newSchemaPath)
 
-  it('should does stuff', function (done) {
+  it('should not cause creation of duplicate records', function (done) {
     config.set('query.useVersionFilter', true)
 
     var client = request(connectionString)

--- a/test/unit/model/index.js
+++ b/test/unit/model/index.js
@@ -519,6 +519,47 @@ describe('Model', function () {
         })
       })
     })
+
+    it('should support unique indexes', function (done) {
+      // help.cleanUpDB()
+      var conn = connection()
+      var fields = help.getModelSchema()
+      var schema = {}
+      schema.fields = fields
+
+      schema.fields.field3 = _.extend({}, schema.fields.fieldName, {
+        type: 'String',
+        required: false
+      })
+
+      var mod = model('testModelName',
+        schema.fields,
+        conn,
+        {
+          index: {
+            enabled: true,
+            keys: {
+              field3: 1
+            },
+            options: {
+              unique: true
+            }
+          }
+        }
+      )
+
+      mod.create({field3: 'ABCDEF'}, function (err, result) {
+        if (err) return done(err)
+
+        mod.create({field3: 'ABCDEF'}, function (err, result) {
+          should.exist(err)
+
+          err.name.should.eql('MongoError')
+          err.code.should.eql('11000')
+          done()
+        })
+      })
+    })
   })
 
   describe('`create` method', function () {


### PR DESCRIPTION
### Collection schema indexes

This PR introduces an extension to the index creation for collections. 

Indexes can be specified one of two ways. The existing config is still compatible:

```
"index": {
  "enabled": true,
  "keys": { "title": 1 }
}
```

The new config allows specifying more than one index for a collection, and giving a set of options to each one:

```
"index": [
  {
    "keys": {
      "field1": 1,
      "field2": -1
    },
    "options": {
      "unique": true
    }
  }
]
```

### Collection schema validation

This PR also adds validation to collection schemas so that if a sort field is specified but no index is specified for that field, an error is returned.

Close #136, #142 
