### PR TITLE
Stop empty apiVersion from being added to composed query

### DIFF
--- a/dadi/lib/composer/index.js
+++ b/dadi/lib/composer/index.js
@@ -56,7 +56,9 @@ Composer.prototype.composeOne = function (doc, callback) {
       }
 
       // add the apiVersion param
-      _.extend(query, { apiVersion: this.apiVersion })
+      if (this.apiVersion) {
+        _.extend(query, { apiVersion: this.apiVersion })  
+      }
 
       // are specific fields required?
       var fields = {}

--- a/dadi/lib/composer/index.js
+++ b/dadi/lib/composer/index.js
@@ -57,7 +57,7 @@ Composer.prototype.composeOne = function (doc, callback) {
 
       // add the apiVersion param
       if (this.apiVersion) {
-        _.extend(query, { apiVersion: this.apiVersion })  
+        _.extend(query, { apiVersion: this.apiVersion })
       }
 
       // are specific fields required?


### PR DESCRIPTION
### Does this resolve an issue?
At the moment composed queries fail when `apiVersion` is `undefined`.

### Description of changes proposed in this pull request
`apiVersion` is only added to the query if its value is truthy.