### PR TITLE
Add media buckets to collections endpoint

### DIFF
--- a/dadi/lib/index.js
+++ b/dadi/lib/index.js
@@ -533,18 +533,13 @@ Server.prototype.loadCollectionRoute = function () {
 
     data.collections = _.sortBy(collections, 'path')
 
-    // Adding media collections. For now, this will contain a single entry, but
-    // it's still worth keeping it as an array in case we support multiple media
-    // collections in the future, avoiding breaking changes.
-    // var mediaCollections = []
-    //
-    // if (config.get('media.enabled')) {
-    //   mediaCollections = [Object.assign({}, MediaModel.Schema, {
-    //     name: config.get('media.collection')
-    //   })]
-    // }
-    //
-    // data.mediaCollections = mediaCollections
+    // Adding media buckets
+    const buckets = config.get('media.buckets').concat(config.get('media.defaultBucket'))
+
+    data.media = {
+      buckets: buckets,
+      defaultBucket: config.get('media.defaultBucket')
+    }
 
     return help.sendBackJSON(200, res, next)(null, data)
   })

--- a/test/acceptance/media.js
+++ b/test/acceptance/media.js
@@ -389,6 +389,43 @@ describe('Media', function () {
           })
         })
       })
+
+      it('should list media buckets in /api/collections endpoint', function (done) {
+        var additionalBuckets = ['bucketOne', 'bucketTwo']
+        var defaultBucket = config.get('media.defaultBucket')
+        var allBuckets = additionalBuckets.concat(defaultBucket)
+
+        var originalBuckets = config.get('media.buckets')
+
+        config.set('media.buckets', additionalBuckets)
+
+        var client = request(connectionString)
+
+        client
+        .get('/api/collections')
+        .set('Authorization', 'Bearer ' + bearerToken)
+        .set('content-type', 'application/json')
+        .expect(200)
+        .end((err, res) => {
+          if (err) return done(err)
+
+          should.exist(res.body.media)
+
+          res.body.media.defaultBucket.should.be.String
+          res.body.media.defaultBucket.should.eql(defaultBucket)
+
+          res.body.media.buckets.should.be.Array
+          res.body.media.buckets.length.should.eql(allBuckets.length)
+          res.body.media.buckets.forEach(bucket => {
+            allBuckets.indexOf(bucket).should.not.eql(-1)
+          })
+
+          // Restore original list of buckets
+          config.set('media.buckets', originalBuckets)
+
+          done()
+        })
+      })
     })
   })
 


### PR DESCRIPTION
This PR adds a list of media buckets to the `/api/collections` endpoint. The output is as follows:

```json
GET /api/endpoints

{
  "collections": [
    {
      "version": "1.0",
      "database": "publish",
      "name": "Articles",
      "slug": "articles",
      "path": "/1.0/publish/articles"
    },
    {
      "version": "1.0",
      "database": "publish",
      "name": "Books",
      "slug": "books",
      "path": "/1.0/publish/books"
    },
    {
      "version": "1.0",
      "database": "publish",
      "name": "Publish authors",
      "slug": "users",
      "path": "/1.0/publish/users"
    }
  ],
  "media": {
    "buckets": [
      "userAvatars",
      "mediaStore"
    ],
    "defaultBucket": "mediaStore"
  }
}
```

This PR adds to #247.

Acceptance test included.