### PR TITLE
fix: more explicit falsy value checks

### DIFF
--- a/dadi/lib/composer/index.js
+++ b/dadi/lib/composer/index.js
@@ -136,11 +136,11 @@ Composer.prototype.createFromComposed = function (doc, req, callback) {
 
     if (Array.isArray(value)) {
       _.each(value, (val) => {
-        if (val.constructor === Object) {
+        if (val && val.constructor === Object) {
           queue.push(this.createOrUpdate(model, key, val, req))
         }
       })
-    } else if (value.constructor === Object) {
+    } else if (value && value.constructor === Object) {
       queue.push(this.createOrUpdate(model, key, value, req))
     }
   })

--- a/dadi/lib/composer/index.js
+++ b/dadi/lib/composer/index.js
@@ -41,7 +41,7 @@ Composer.prototype.composeOne = function (doc, callback) {
     var returnArray = false
     var value = doc[key]
 
-    if (!value) return callback(null)
+    if (!value && typeof value !== 'undefined') return callback(null)
 
     if (value.constructor === Object) {
       if (keyIdx === composable.length) {

--- a/dadi/lib/composer/index.js
+++ b/dadi/lib/composer/index.js
@@ -41,7 +41,7 @@ Composer.prototype.composeOne = function (doc, callback) {
     var returnArray = false
     var value = doc[key]
 
-    if (!value && typeof value !== 'undefined') return callback(null)
+    if (!value || typeof value === 'undefined') return callback(null)
 
     if (value.constructor === Object) {
       if (keyIdx === composable.length) {

--- a/dadi/lib/composer/index.js
+++ b/dadi/lib/composer/index.js
@@ -41,7 +41,7 @@ Composer.prototype.composeOne = function (doc, callback) {
     var returnArray = false
     var value = doc[key]
 
-    if (!value || typeof value === 'undefined') return callback(null)
+    if (value === null || typeof value === 'undefined') return callback(null)
 
     if (value.constructor === Object) {
       if (keyIdx === composable.length) {


### PR DESCRIPTION
This fix addresses an issue where the property `value` may exist, but be _undefined_. The exit clause in this instance does not fire, this leaving the property open to further scrutiny