### PR TITLE
🚧 [Do not merge] Fix hook loops

### DIFF
--- a/dadi/lib/controller/index.js
+++ b/dadi/lib/controller/index.js
@@ -139,7 +139,9 @@ Controller.prototype.get = function (req, res, next) {
     queryOptions = queryOptions.queryOptions
   }
 
-  this.model.get(query, queryOptions, done, req)
+  this.model.get(query, queryOptions, done, req, {
+    runHooks: true
+  })
 }
 
 Controller.prototype.prepareQueryOptions = function (options) {
@@ -230,14 +232,18 @@ Controller.prototype.post = function (req, res, next) {
         query.apiVersion = internals.apiVersion
       }
 
-      return self.model.update(query, update, internals, sendBackJSON(200, res, next), req)
+      return self.model.update(query, update, internals, sendBackJSON(200, res, next), req, {
+        runHooks: true
+      })
     }
 
     // if no id is present, then this is a create
     internals.createdAt = Date.now()
     internals.createdBy = req.client && req.client.clientId
 
-    self.model.create(req.body, internals, sendBackJSON(200, res, next), req)
+    self.model.create(req.body, internals, sendBackJSON(200, res, next), req, {
+      runHooks: true
+    })
   })
 }
 
@@ -276,7 +282,9 @@ Controller.prototype.delete = function (req, res, next) {
       // send no-content success
       res.statusCode = 204
       res.end()
-    }, req)
+    }, req, {
+      runHooks: true
+    })
   })
 }
 


### PR DESCRIPTION
This PR adds an options object to the `create`, `delete`, `get` and `update` model functions. It accepts a boolean property called `runHooks` that determines whether hooks should be executed as part of the model call.

This **defaults to false**, which means that any manual calls to model functions (e.g. inside hooks) won't trigger hooks unless the `runHooks` option is explicitly set to `true`. In other words, hooks triggering other hooks will only happen if hook authors actively add that functionality.

Controllers have been updated with this property so that collection endpoints still run hooks normally. Existing unit tests have been updated and new tests have been added.

This closes #258.