### PR TITLE
fix: ignore _id field in query when making case insensitive

### DIFF
--- a/dadi/lib/model/utils.js
+++ b/dadi/lib/model/utils.js
@@ -99,7 +99,7 @@ function makeCaseInsensitive (obj, schema) {
   var newObj = _.clone(obj)
 
   _.each(Object.keys(obj), function (key) {
-    if (key === 'apiVersion') {
+    if (key === 'apiVersion' || key === '_id') {
       return
     }
 

--- a/test/unit/model/utils.js
+++ b/test/unit/model/utils.js
@@ -125,6 +125,19 @@ describe('Query Utils', function () {
   })
 
   describe('`makeCaseInsensitive` method', function () {
+    it('should not convert _id values in a query', function (done) {
+      var schema = help.getModelSchema()
+      schema['fieldName'].type = 'Object'
+
+      var query = { '_id': '1234' }
+      var expected = { '_id': '1234' }
+
+      var result = queryUtils.makeCaseInsensitive(query, schema)
+
+      result.should.eql(expected)
+      done()
+    })
+
     it('should convert a normal field query to a case insensitive regex query if schema doesn\'t specify otherwise', function (done) {
       var schema = help.getModelSchema()
       var query = { 'fieldName': 'example' }


### PR DESCRIPTION
If a user app sends a query containing a MongoDB ObjectId as the `_id` value, without first stringifying the `_id`, API attempts to make it case-insensitive and it becomes `{ _id: }`

This PR introduces a change which ignores _id keys when processing the query.

Fix #246 
