### PR TITLE
fix: write deleted document to history

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,18 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## [1.16.8] (2017-06-08)
+
+### Changed
+* add additional property `action` to history revision documents. Possible values are `"update", "delete"` and the appropriate value is selected when updating/deleting records
+
+### Added
+* [#298](https://github.com/dadi/api/issues/298): documents to be deleted will first have the current state written into the history collection, if enabled
+
+## [1.16.7] (2017-05-30)
+
+* fix product logo in README
+
 ## [1.16.6] (2017-05-25)
 
 ### Changed

--- a/dadi/lib/model/history.js
+++ b/dadi/lib/model/history.js
@@ -32,11 +32,13 @@ History.prototype.create = function (obj, model, done) {
   model.connection.once('connect', _done)
 }
 
-History.prototype.createEach = function (objs, model, done) {
+History.prototype.createEach = function (objs, action, model, done) {
   var self = this
   var updatedDocs = []
 
   objs.forEach(function (obj, index, array) {
+    obj.action = action
+
     self.create(obj, model, function (err, doc) {
       if (err) return done(err)
 

--- a/dadi/lib/model/history.js
+++ b/dadi/lib/model/history.js
@@ -9,6 +9,7 @@ History.prototype.create = function (obj, model, done) {
   // create copy of original
   var revisionObj = _.clone(obj)
   revisionObj._id = new ObjectID()
+  revisionObj.originalDocumentId = obj._id
 
   var _done = function (database) {
     database.collection(model.revisionCollection).insert(revisionObj, function (err, doc) {

--- a/dadi/lib/model/index.js
+++ b/dadi/lib/model/index.js
@@ -901,7 +901,7 @@ Model.prototype.update = function (query, update, internals, done, req) {
           // for each of the updated documents, create
           // a history revision for it
           if (this.history && updatedDocs.length > 0) {
-            this.history.createEach(updatedDocs, this, (err, docs) => {
+            this.history.createEach(updatedDocs, 'update', this, (err, docs) => {
               if (err) return done(err)
 
               return getDocumentsForResponse(done)
@@ -955,6 +955,7 @@ Model.prototype.update = function (query, update, internals, done, req) {
  */
 Model.prototype.delete = function (query, done, req) {
   var validation = this.validate.query(query)
+
   if (!validation.success) {
     var err = validationError('Bad Query')
     err.json = validation
@@ -993,19 +994,52 @@ Model.prototype.delete = function (query, done, req) {
   }
 
   var deleteDocuments = (database) => {
-    database.collection(this.name).remove(query, (err, docs) => {
-      if (!err && (docs > 0)) {
-        // apply any existing `afterDelete` hooks
-        if (this.settings.hasOwnProperty('hooks') && (typeof this.settings.hooks.afterDelete === 'object')) {
-          this.settings.hooks.afterDelete.forEach((hookConfig, index) => {
-            var hook = new Hook(this.settings.hooks.afterDelete[index], 'afterDelete')
+    if (query._id) {
+      query._id = query._id.toString()
+    }
 
-            return hook.apply(query, this.schema, this.name)
-          })
+    var wait = Promise.resolve()
+
+    if (this.history) {
+      wait = new Promise((resolve, reject) => {
+        this.find(query, { compose: false }, (err, docs) => {
+          if (err) return reject(err)
+
+          var deletedDocs = docs.results
+
+          // for each of the about-to-be-deleted documents, create a revision for it
+          if (deletedDocs.length > 0) {
+            this.history.createEach(deletedDocs, 'delete', this, (err, docs) => {
+              if (err) return reject(err)
+
+              return resolve()
+            })
+          } else {
+            return resolve()
+          }
+        })
+      })
+    }
+
+    wait.then(() => {
+      query = queryUtils.convertApparentObjectIds(query, this.schema)
+
+      database.collection(this.name).remove(query, (err, docs) => {
+        if (!err && (docs > 0)) {
+          // apply any existing `afterDelete` hooks
+          if (this.settings.hasOwnProperty('hooks') && (typeof this.settings.hooks.afterDelete === 'object')) {
+            this.settings.hooks.afterDelete.forEach((hookConfig, index) => {
+              var hook = new Hook(this.settings.hooks.afterDelete[index], 'afterDelete')
+
+              return hook.apply(query, this.schema, this.name)
+            })
+          }
         }
-      }
 
-      done(err, docs)
+        done(err, docs)
+      })
+    }).catch((err) => {
+      done(err)
     })
   }
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dadi/api",
-  "version": "1.16.7",
+  "version": "1.16.8",
   "main": "main.js",
   "scripts": {
     "create-client": "cd ../../.. && node ./node_modules/@dadi/api/utils/create-client.js",

--- a/test/unit/model/history.js
+++ b/test/unit/model/history.js
@@ -87,7 +87,7 @@ describe('History', function () {
           mod.find({}, function (err, docs) {
             if (err) return done(err)
 
-            mod.history.createEach(docs['results'], mod, function (err, res) {
+            mod.history.createEach(docs['results'], 'update', mod, function (err, res) {
               if (err) return done(err)
 
               mod.find({}, function (err, docs) {


### PR DESCRIPTION
Fix #298 

### Changed
* add additional property `action` to history revision documents. Possible values are `"update", "delete"` and the appropriate value is selected when updating/deleting records
* add additional property `originalDocumentId` to history revision documents

### Added
* [#298](https://github.com/dadi/api/issues/298): documents to be deleted will first have the current state written into the history collection, if enabled
