### PR TITLE
store deleted revision, and add detail

### DIFF
--- a/dadi/lib/model/history.js
+++ b/dadi/lib/model/history.js
@@ -9,6 +9,7 @@ History.prototype.create = function (obj, model, done) {
   // create copy of original
   var revisionObj = _.clone(obj)
   revisionObj._id = new ObjectID()
+  revisionObj.originalDocumentId = obj._id
 
   var _done = function (database) {
     database.collection(model.revisionCollection).insertOne(revisionObj, function (err, doc) {
@@ -35,11 +36,13 @@ History.prototype.create = function (obj, model, done) {
   model.connection.once('connect', _done)
 }
 
-History.prototype.createEach = function (objs, model, done) {
+History.prototype.createEach = function (objs, action, model, done) {
   var self = this
   var updatedDocs = []
 
   objs.forEach(function (obj, index, array) {
+    obj.action = action
+
     self.create(obj, model, function (err, doc) {
       if (err) return done(err)
 

--- a/test/unit/model/history.js
+++ b/test/unit/model/history.js
@@ -26,7 +26,6 @@ describe('History', function () {
 
       done()
     })
-
   })
 
   describe('`create` method', function () {
@@ -87,7 +86,7 @@ describe('History', function () {
           mod.find({}, function (err, docs) {
             if (err) return done(err)
 
-            mod.history.createEach(docs['results'], mod, function (err, res) {
+            mod.history.createEach(docs['results'], 'update', mod, function (err, res) {
               if (err) return done(err)
 
               mod.find({}, function (err, docs) {
@@ -102,11 +101,60 @@ describe('History', function () {
             })
           })
         })
-
       })
-
     })
 
-  })
+    it('should add action=update to history revisions when a document is updated', function (done) {
+      var conn = connection()
+      var mod = model('testModelName', help.getModelSchema(), conn, { storeRevisions: true })
 
+      mod.create({ fieldName: 'foo-1' }, function (err, result) {
+        mod.update({ fieldName: 'foo-1' }, { fieldName: 'foo-2' }, function (err, result) {
+          mod.find({}, { includeHistory: true }, function (err, docs) {
+            should.exist(docs.results[0].history)
+            should.exist(docs.results[0].history[0])
+            should.exist(docs.results[0].history[0].action)
+            docs.results[0].history[0].action.should.eql('update')
+            done()
+          })
+        })
+      })
+    })
+
+    it('should add action=delete to history revisions when a document is deleted', function (done) {
+      var conn = connection()
+      var mod = model('testModelName', help.getModelSchema(), conn, { storeRevisions: true })
+
+      mod.create({ fieldName: 'foo-1' }, function (err, result) {
+        mod.delete({ fieldName: 'foo-1' }, function (err, result) {
+          mod = model('testModelNameHistory', help.getModelSchema(), conn, { storeRevisions: false })
+          mod.find({}, {}, function (err, docs) {
+            should.exist(docs.results[0])
+            should.exist(docs.results[0].originalDocumentId)
+            should.exist(docs.results[0].action)
+            docs.results[0].action.should.eql('delete')
+            done()
+          })
+        })
+      })
+    })
+
+    it('should add the original document id to history revisions', function (done) {
+      var conn = connection()
+      var mod = model('testModelName', help.getModelSchema(), conn, { storeRevisions: true })
+
+      mod.create({ fieldName: 'foo-1' }, function (err, result) {
+        var id = result.results[0]._id
+        mod.update({ fieldName: 'foo-1' }, { fieldName: 'foo-2' }, function (err, result) {
+          mod.find({}, { includeHistory: true }, function (err, docs) {
+            should.exist(docs.results[0].history)
+            should.exist(docs.results[0].history[0])
+            should.exist(docs.results[0].history[0].originalDocumentId)
+            docs.results[0].history[0].originalDocumentId.should.eql(id)
+            done()
+          })
+        })
+      })
+    })
+  })
 })


### PR DESCRIPTION
Fix #298 

* add action and originalDocumentId properties to revision documents
* store revision history when documents are deleted

