### PR TITLE
Update hook error handling

### DIFF
--- a/dadi/lib/model/hook.js
+++ b/dadi/lib/model/hook.js
@@ -1,5 +1,6 @@
 'use strict'
 
+const formatError = require('@dadi/format-error')
 const path = require('path')
 const config = require(path.join(__dirname, '/../../../config'))
 
@@ -111,6 +112,24 @@ Hook.prototype.apply = function () {
   }
 
   return false
+}
+
+/**
+ * Builds an error object for the given hook error
+ *
+ * @param Error
+ * @return Object
+ * @api public
+ */
+Hook.prototype.formatError = function (error) {
+  const errorCode = error.code ? error : '0002'
+  const errorMessage = error.message +
+    (error.stack ? '\n' + error.stack.split('\n')[1] : '')
+
+  return [formatError.createApiError(errorCode, {
+    hookName: this.getName(),
+    errorMessage: errorMessage
+  })]
 }
 
 /**

--- a/dadi/lib/model/index.js
+++ b/dadi/lib/model/index.js
@@ -233,10 +233,7 @@ Model.prototype.create = function (documents, internals, done, req) {
           Promise.resolve(hook.apply(current, this.schema, this.name, req)).then((newDoc) => {
             callback((newDoc === null) ? {} : null, newDoc)
           }).catch(err => {
-            callback([formatError.createApiError('0002', {
-              hookName: hook.getName(),
-              errorMessage: err
-            })])
+            callback(hook.formatError(err))
           })
         }, (err, result) => {
           processedDocs++
@@ -708,11 +705,8 @@ Model.prototype.get = function (query, options, done, req) {
 
         Promise.resolve(hook.apply(current, this.schema, this.name, req)).then((newResults) => {
           callback((newResults === null) ? {} : null, newResults)
-        }).catch((err) => {
-          callback([formatError.createApiError('0002', {
-            hookName: hook.getName(),
-            errorMessage: err + '\n' + err.stack ? err.stack.split('\n')[1] : ''
-          })])
+        }).catch(err => {
+          callback(hook.formatError(err))
         })
       }, (err, finalResult) => {
         done(err, finalResult)
@@ -942,11 +936,8 @@ Model.prototype.update = function (query, update, internals, done, req) {
 
           Promise.resolve(hook.apply(current, updatedDocs, this.schema, this.name, req)).then((newUpdate) => {
             callback((newUpdate === null) ? {} : null, newUpdate)
-          }).catch((err) => {
-            callback([formatError.createApiError('0002', {
-              hookName: hook.getName(),
-              errorMessage: err + '\n' + err.stack ? err.stack.split('\n')[1] : ''
-            })])
+          }).catch(err => {
+            callback(hook.formatError(err))
           })
         }, (err, result) => {
           if (err) {
@@ -999,10 +990,7 @@ Model.prototype.delete = function (query, done, req) {
         Promise.resolve(hook.apply(current, hookError, this.schema, this.name, req)).then((newQuery) => {
           callback((newQuery === null) ? {} : null, newQuery)
         }).catch((err) => {
-          callback([formatError.createApiError('0002', {
-            hookName: hook.getName(),
-            errorMessage: err
-          })])
+          callback(hook.formatError(err))
         })
       }, (err, result) => {
         if (err) {

--- a/dadi/lib/model/index.js
+++ b/dadi/lib/model/index.js
@@ -6,7 +6,6 @@ var path = require('path')
 
 var config = require(path.join(__dirname, '/../../../config'))
 var connection = require(path.join(__dirname, '/connection'))
-var formatError = require('@dadi/format-error')
 var logger = require('@dadi/logger')
 var Validator = require(path.join(__dirname, '/validator'))
 var History = require(path.join(__dirname, '/history'))

--- a/test/unit/model/hooks.js
+++ b/test/unit/model/hooks.js
@@ -151,6 +151,72 @@ describe('Hook', function () {
     })
   })
 
+  describe('`formatError` method', function (done) {
+    it('should return an API-0002 error object for a regular user-thrown error', function (done) {
+      sinon.stub(hook.Hook.prototype, 'load').returns(simpleFunction)
+
+      var hookName = 'test-hook'
+      var h = new hook(hookName, 'beforeCreate')
+      var errorMessage = 'This is a user-thrown error'
+
+      hook.Hook.prototype.load.restore()
+
+      var error = new Error(errorMessage)
+      var errorObject = h.formatError(error)
+
+      errorObject[0].code.should.equal('API-0002')
+      errorObject[0].title.should.equal('Hook Error')
+      errorObject[0].details.indexOf(errorMessage).should.not.equal(-1)
+
+      done()
+    })
+
+    it('should return an API-0002 error object for a regular runtime error', function (done) {
+      sinon.stub(hook.Hook.prototype, 'load').returns(simpleFunction)
+
+      var hookName = 'test-hook'
+      var h = new hook(hookName, 'beforeCreate')
+
+      hook.Hook.prototype.load.restore()
+
+      var error
+
+      try {
+        thisFunctionDoesNotExist()
+      } catch (err) {
+        error = err
+      }
+
+      var errorObject = h.formatError(error)
+
+      errorObject[0].code.should.equal('API-0002')
+      errorObject[0].title.should.equal('Hook Error')
+      errorObject[0].details.indexOf(hookName).should.not.equal(-1)
+
+      done()
+    })
+
+    it('should return a custom error object for a custom error (defined by a `code` property)', function (done) {
+      sinon.stub(hook.Hook.prototype, 'load').returns(simpleFunction)
+
+      var hookName = 'test-hook'
+      var h = new hook(hookName, 'beforeCreate')
+      var customErrorCode = 'MY-CUSTOM-ERROR'
+
+      hook.Hook.prototype.load.restore()
+
+      var error = new Error('custom error')
+
+      error.code = customErrorCode
+
+      var errorObject = h.formatError(error)
+
+      errorObject[0].code.should.equal(customErrorCode)
+
+      done()
+    })
+  })
+
   describe('`beforeCreate` hook', function () {
     beforeEach(help.cleanUpDB)
 


### PR DESCRIPTION
Currently, any error that occurs inside a hook is displayed as an error object with a `code` of `API-0002` and a `details` property containing the error message and, more recently, the first line of the stack trace. This is great for debugging and tracking down runtime errors, but errors in hooks can mean different things.

For example, in Publish we use a hook to implement a custom authentication layer that sits on top of API's native auth. Within this hook, we have several different error conditions we need to be able to communicate back to the consumer that are not generated by a run time error. These are things like "the login/password combination provided is invalid" or "the email address already exists". For these cases, the current method is not ideal. In essence, we need the ability for hooks to throw custom errors that are reported differently.

With this PR, API looks at any error coming from a hook and checks whether it's a custom error (by looking for a `code` property). If it exists, it formats the error object with that custom code, so that consumers can easily understand what happened exactly.

*Example responses:*

```json
// Before (it involves parsing `details` to check for a custom error code
[
    {
        "code": "API-0002",
        "title": "Hook Error",
        "details": "The hook 'publish-auth' failed: 'WRONG_CREDENTIALS'",
        "docLink": "http://docs.dadi.tech/errors/api/API-0002"
    }
]

// After (we just need to look at the `code` property)
// We could also add a `details` property with a human-friendly
// description of the error.
[
    {
        "code": "WRONG_CREDENTIALS"
    }
]
```

Note that for normal runtime errors the output will remain unchanged.