### PR TITLE
Ensure only collection endpoints are added to collections endpoint

### DIFF
--- a/dadi/lib/index.js
+++ b/dadi/lib/index.js
@@ -493,13 +493,14 @@ Server.prototype.loadCollectionRoute = function () {
       var slug
       var parts = _.compact(key.split('/'))
 
-      var hasModel = _.contains(Object.keys(value), 'model')
+      var hasModel = _.contains(Object.keys(value), 'model') &&
+        value.model.constructor.name === 'Model'
       var hasGetMethod = _.contains(Object.keys(value), 'get')
 
       if (hasModel && !hasGetMethod) {
         model = value.model
 
-        if (model.hasOwnProperty('name')) {
+        if (model.name) {
           name = model.name
           slug = model.name
         }


### PR DESCRIPTION
This PR fixes an issue where, in some cases, custom endpoints are added to the `/api/collections` endpoint. This fix checks to see whether the `model` property in the component is an actual instance of `Model`.