### PR TITLE
Add better support for custom hook errors

### DIFF
--- a/dadi/lib/model/hook.js
+++ b/dadi/lib/model/hook.js
@@ -123,12 +123,27 @@ Hook.prototype.apply = function () {
  */
 Hook.prototype.formatError = function (error) {
   const errorCode = error.code ? error : '0002'
-  const errorMessage = error.message +
-    (error.stack ? '\n' + error.stack.split('\n')[1] : '')
+
+  let errorMessage
+
+  // If `error` is a string and not an actual Error object,
+  // we'll use that as the message.
+  if (typeof error === 'string') {
+    errorMessage = error
+  } else {
+    errorMessage = error.message || ''
+    errorMessage += (error.stack ? '\n' + error.stack.split('\n')[1] : '')
+
+    // If this is a custom error, we attach the name of the hook.
+    if (error.dadiCustomError && !error.dadiCustomError.hookName) {
+      error.dadiCustomError.hookName = this.getName()
+    }
+  }
 
   return [formatError.createApiError(errorCode, {
-    hookName: this.getName(),
-    errorMessage: errorMessage
+    error: error,
+    errorMessage: errorMessage,
+    hookName: this.getName()
   })]
 }
 

--- a/test/unit/model/hooks.js
+++ b/test/unit/model/hooks.js
@@ -152,7 +152,25 @@ describe('Hook', function () {
   })
 
   describe('`formatError` method', function (done) {
-    it('should return an API-0002 error object for a regular user-thrown error', function (done) {
+    it('should return an API-0002 error object for a user-thrown error as string', function (done) {
+      sinon.stub(hook.Hook.prototype, 'load').returns(simpleFunction)
+
+      var hookName = 'test-hook'
+      var h = new hook(hookName, 'beforeCreate')
+      var errorMessage = 'This is a user-thrown error'
+
+      hook.Hook.prototype.load.restore()
+
+      var errorObject = h.formatError(errorMessage)
+
+      errorObject[0].code.should.equal('API-0002')
+      errorObject[0].title.should.equal('Hook Error')
+      errorObject[0].details.indexOf(errorMessage).should.not.equal(-1)
+
+      done()
+    })
+
+    it('should return an API-0002 error object for a user-thrown Error object', function (done) {
       sinon.stub(hook.Hook.prototype, 'load').returns(simpleFunction)
 
       var hookName = 'test-hook'
@@ -171,7 +189,7 @@ describe('Hook', function () {
       done()
     })
 
-    it('should return an API-0002 error object for a regular runtime error', function (done) {
+    it('should return an API-0002 error object for a runtime error', function (done) {
       sinon.stub(hook.Hook.prototype, 'load').returns(simpleFunction)
 
       var hookName = 'test-hook'
@@ -196,22 +214,57 @@ describe('Hook', function () {
       done()
     })
 
-    it('should return a custom error object for a custom error (defined by a `code` property)', function (done) {
+    it('should return a custom error object for a custom error (defined by a `dadiCustomError` property)', function (done) {
       sinon.stub(hook.Hook.prototype, 'load').returns(simpleFunction)
 
       var hookName = 'test-hook'
       var h = new hook(hookName, 'beforeCreate')
-      var customErrorCode = 'MY-CUSTOM-ERROR'
 
       hook.Hook.prototype.load.restore()
 
+      var errorData = {
+        code: 'MY_CUSTOM_ERROR',
+        someData: {
+          _id: 123456,
+          name: 'foobar'
+        }
+      }
+
       var error = new Error('custom error')
 
-      error.code = customErrorCode
+      error.dadiCustomError = Object.assign({}, errorData)
 
       var errorObject = h.formatError(error)
 
-      errorObject[0].code.should.equal(customErrorCode)
+      errorObject[0].code.should.eql(errorData.code)
+      JSON.stringify(errorObject[0].someData).should.eql(JSON.stringify(errorData.someData))
+
+      done()
+    })
+
+    it('should attach the name of the hook to custom errors', function (done) {
+      sinon.stub(hook.Hook.prototype, 'load').returns(simpleFunction)
+
+      var hookName = 'test-hook'
+      var h = new hook(hookName, 'beforeCreate')
+
+      hook.Hook.prototype.load.restore()
+
+      var errorData = {
+        code: 'MY_CUSTOM_ERROR',
+        someData: {
+          _id: 123456,
+          name: 'foobar'
+        }
+      }
+
+      var error = new Error('custom error')
+
+      error.dadiCustomError = Object.assign({}, errorData)
+
+      var errorObject = h.formatError(error)
+
+      errorObject[0].hookName.should.eql(hookName)
 
       done()
     })


### PR DESCRIPTION
## Overview

This PR adds better support for custom errors thrown by hooks. It introduces the concept of custom errors, which are `Error` objects containing a `dadiCustomError` object. This object should contain a `code` (String) property and any arbitrary data that the hook wishes to pass back in the error message.

It also fixes the regression observed in #289.

The section below shows a few different ways of throwing errors in hooks and what their output will be like.

## Dependencies

This PR requires https://github.com/dadi/format-error/pull/4.

## Error types in hooks

1. An unexpected runtime error (includes stack trace)

    *Code:*
    ```js
    functionThatDoesNotExist()
    ```

    *Response:*
    ```json
    {
        "success": false,
        "errors": [
            {
                "code": "API-0002",
                "title": "Hook Error",
                "details": "The hook 'slugify' failed: 'functionThatDoesNotExist is not defined\n    at Hook.module.exports (/Users/eduardoboucas/Sites/publish-api/workspace/hooks/slugify.js:20:3)'",
                "docLink": "http://docs.dadi.tech/errors/api/API-0002"
            }
        ]
    }
    ```

1. User-thrown error, as a string

    *Code:*
    ```js
    // Synchronous
    throw 'Some error'

    // Asynchronous
    return Promise.reject('Some error')
    ```

    *Response:*
    ```json
    {
        "success": false,
        "errors": [
            {
                "code": "API-0002",
                "title": "Hook Error",
                "details": "The hook 'slugify' failed: 'Some error'",
                "docLink": "http://docs.dadi.tech/errors/api/API-0002"
            }
        ]
    }
    ```

1. User-thrown error, as an Error object (includes stack trace)

    *Code:*
    ```js
    var errorObj = new Error('Some error')

    // Synchronous
    throw errorObj

    // Asynchronous
    return Promise.reject(errorObj)
    ```

    *Response:*
    ```json
    {
        "success": false,
        "errors": [
            {
                "code": "API-0002",
                "title": "Hook Error",
                "details": "The hook 'slugify' failed: 'Some error\n    at Hook.module.exports (/Users/eduardoboucas/Sites/publish-api/workspace/hooks/slugify.js:20:12)'",
                "docLink": "http://docs.dadi.tech/errors/api/API-0002"
            }
        ]
    }
    ```

1. User-thrown custom error (identified by a `dadiCustomError` object)

    *Code:*
    ```js
    var customError = new Error('My custom error')

    customError.dadiCustomError = {
      code: 'SLUG_ALREADY_EXISTS',
      document: {
        _id: '1234',
        name: 'John Doe'
      }
    }

    // Synchronous
    throw customError

    // Asynchronous
    return Promise.reject(customError)
    ```

    *Response:*
    ```json
    {
        "success": false,
        "errors": [
            {
                "code": "SLUG_ALREADY_EXISTS",
                "document": {
                    "_id": "1234",
                    "name": "John Doe"
                },
                "hookName": "slugify"
            }
        ]
    }
    ```