### PR TITLE
fix: add reference id values to one array on the original doc

### DIFF
--- a/dadi/lib/composer/index.js
+++ b/dadi/lib/composer/index.js
@@ -170,12 +170,19 @@ Composer.prototype.createFromComposed = function (doc, req, callback) {
   Promise.all(queue).then((results) => {
     var allProperties = {}
 
-    _.each(_.compact(results), (result) => {
+    _.each(_.compact(results), result => {
       var key = Object.keys(result)[0]
+
       if (!allProperties[key]) {
+        // add the value to the field as a simple string
         allProperties[key] = result[key]
       } else {
-        allProperties[key] = [allProperties[key]]
+        // create an array for this key, another value needs to be added
+        if (!Array.isArray(allProperties[key])) {
+          allProperties[key] = [allProperties[key]]
+        }
+
+        // push the new value
         allProperties[key].push(result[key])
       }
     })
@@ -244,8 +251,10 @@ Composer.prototype.createOrUpdate = function (model, field, obj, req) {
         }
 
         var newDoc = results && results.results && results.results[0]
+
         var result = {}
         result[field] = newDoc._id.toString()
+
         return resolve(result)
       })
     }

--- a/test/acceptance/fields/reference.js
+++ b/test/acceptance/fields/reference.js
@@ -121,6 +121,59 @@ describe('Reference Field', function () {
       })
     })
 
+    it('should create multiple reference documents that don\'t have _id fields', function (done) {
+      var data = {
+        "word": "animals",
+        "children": [
+          {
+            "word": "dogs",
+            "children": [
+              {
+                "word": "guide_dogs",
+                "children": []
+              },
+              {
+                "word": "puppies",
+                "children": []
+              }
+            ]
+          },
+          {
+            "word": "foxes",
+            "children": []
+          },
+          {
+            "word": "pandas",
+            "children": []
+          }
+        ]
+      }
+
+      config.set('query.useVersionFilter', true)
+
+      var client = request(connectionString)
+      client
+      .post('/v1/library/taxonomy')
+      .set('Authorization', 'Bearer ' + bearerToken)
+      .send(data)
+      .expect(200)
+      .end(function (err, res) {
+        if (err) return done(err)
+
+        should.exist(res.body.results)
+        var newDoc = res.body.results[0]
+
+        should.exist(newDoc.word)
+        newDoc.word.should.eql('animals')
+
+        newDoc.children.length.should.eql(3)
+        newDoc.children[0].word.should.eql('dogs')
+        newDoc.children[1].word.should.eql('foxes')
+        newDoc.children[2].word.should.eql('pandas')
+        done()
+      })
+    })
+
     it('should update reference documents that already have _id fields', function (done) {
       var person = {
         name: 'Ernest Hemingway'

--- a/test/acceptance/workspace/collections/v1/library/collection.taxonomy.json
+++ b/test/acceptance/workspace/collections/v1/library/collection.taxonomy.json
@@ -1,0 +1,36 @@
+{
+  "fields": {
+    "word": {
+      "type": "String",
+      "label": "Word",
+      "comments": "Taxanomic word",
+      "validation": {},
+      "required": true,
+      "message": "can't be empty"
+    },
+    "children": {
+      "type": "Reference",
+      "label": "Children",
+      "required": false,
+      "settings": {
+        "collection": "taxonomy",
+        "multiple": true
+      }
+    }
+  },
+  "settings": {
+    "compose": true,
+    "cache": false,
+    "authenticate": true,
+    "callback": null,
+    "defaultFilters": null,
+    "fieldLimiters": null,
+    "count": 40,
+    "sort": "createdAt",
+    "sortOrder": 1,
+    "limit": 1,
+    "storeRevisions": true,
+    "description": "Taxonomy",
+    "displayName": "Taxonomy"
+  }
+}


### PR DESCRIPTION
A bug caused multiple child reference fields for the same parent to each be added to a nested array, rather than adding all of them to a single parent array. 

Fix #311 

