### PR TITLE
Add beforeGet hook

### DIFF
--- a/dadi/lib/model/hook.js
+++ b/dadi/lib/model/hook.js
@@ -9,6 +9,7 @@ const config = require(path.join(__dirname, '/../../../config'))
  *
  * beforeCreate
  * afterCreate
+ * beforeGet
  * afterGet
  * beforeUpdate
  * afterUpdate
@@ -67,6 +68,14 @@ Hook.prototype.apply = function () {
       return this.hook(arguments[0], this.type, {
         collection: arguments[2],
         options: this.options,
+        schema: arguments[1]
+      })
+
+    case 'beforeGet':
+      return this.hook(arguments[0], this.type, {
+        collection: arguments[2],
+        options: this.options,
+        req: arguments[3],
         schema: arguments[1]
       })
 


### PR DESCRIPTION
This PR adds support for a new type of hook called `beforeGet`. It gets processed before a collection is queried and the hook receives an object representing the query, which it can manipulate. Similarly to other hook types, it can be asynchronous. Runtime and custom errors will be captured.

Closes #189.