### PR TITLE
fix: ignore Reference field ids when converting

### DIFF
--- a/dadi/lib/model/utils.js
+++ b/dadi/lib/model/utils.js
@@ -87,7 +87,7 @@ function convertApparentObjectIds (query, schema) {
       } else if (typeof type === 'undefined' || type !== 'Reference') { // Don't convert query id when it's a Reference field
         query[key] = convertApparentObjectIds(query[key], schema)
       }
-    } else if (typeof query[key] === 'string' && !/^Mixed|Object$/.test(type) && ObjectID.isValid(query[key]) && query[key].match(/^[a-fA-F0-9]{24}$/)) {
+    } else if (typeof query[key] === 'string' && !/^Mixed|Reference|Object$/.test(type) && ObjectID.isValid(query[key]) && query[key].match(/^[a-fA-F0-9]{24}$/)) {
       query[key] = ObjectID.createFromHexString(query[key])
     }
   })


### PR DESCRIPTION
Fix #319 

When querying for documents that would be deleted, and the query contained a Reference field id, API was converting the id to a MongoDB ObjectID, rather than leaving it as a string.

Example:

The query:

```
{
  "query": {
    "author": "5978d21d136f133bfd926798"
  }
}
```

Would become `{ "author": ObjectId("5978d21d136f133bfd926798") }`, which doesn't match anything, so ALL documents are returned.
