### PR TITLE
fix: remove null or undefined array values

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 <img src="https://dadi.tech/assets/products/dadi-api-full.png" alt="DADI API" height="65"/>
 
 [![npm (scoped)](https://img.shields.io/npm/v/@dadi/api.svg?maxAge=10800&style=flat-square)](https://www.npmjs.com/package/@dadi/api)
-[![coverage](https://img.shields.io/badge/coverage-87%25-yellow.svg?style=flat?style=flat-square)](https://github.com/dadi/api)
+[![coverage](https://img.shields.io/badge/coverage-88%25-yellow.svg?style=flat?style=flat-square)](https://github.com/dadi/api)
 [![Build Status](https://travis-ci.org/dadi/api.svg?branch=master)](https://travis-ci.org/dadi/api)
 [![JavaScript Style Guide](https://img.shields.io/badge/code%20style-standard-brightgreen.svg?style=flat-square)](http://standardjs.com/)
 
@@ -212,3 +212,4 @@ A copy can be found in the file GPL.md distributed with
 these files.
 
 This copyright notice MUST APPEAR in all copies of the product!
+

--- a/dadi/lib/model/utils.js
+++ b/dadi/lib/model/utils.js
@@ -219,11 +219,11 @@ function removeInternalFields (obj) {
   return obj
 }
 
-function removeEmptyArrayProperties (value) {
-  if (Array.isArray(value)) {
-    return value.filter(value => value !== null && typeof value !== 'undefined')
+function removeEmptyArrayProperties (inputValue) {
+  if (Array.isArray(inputValue)) {
+    return inputValue.filter(value => value !== null && typeof value !== 'undefined')
   } else {
-    return value
+    return inputValue
   }
 }
 

--- a/dadi/lib/model/utils.js
+++ b/dadi/lib/model/utils.js
@@ -219,14 +219,24 @@ function removeInternalFields (obj) {
   return obj
 }
 
+function removeEmptyArrayProperties (value) {
+  if (Array.isArray(value)) {
+    return value.filter(value => value !== null && typeof value !== 'undefined')
+  } else {
+    return value
+  }
+}
+
 function stringifyProperties (obj) {
   _.each(Object.keys(obj), (key) => {
     try {
+      // Remove invalid array properties
+      obj[key] = removeEmptyArrayProperties(obj[key])
+
       if (typeof obj[key] === 'string' && validator.isMongoId(obj[key].toString())) {
         obj[key] = obj[key].toString()
       } else if (typeof obj[key] === 'object' && obj[key] !== null) {
         var value = obj[key].toString()
-
         // console.log('stringifyProperties', value, typeof value, obj[key], typeof obj[key])
 
         if (Array.isArray(obj[key])) {


### PR DESCRIPTION
This PR addresses an issue with object > string mutation on arrays containing `null`, e.g. `[null]`.

If the subject is an array, a filter is applied to remove any undefined or null values. 