### PR TITLE
fix: check all parent categories for linked filters

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,6 @@ notifications:
 node_js:
   - '6'
   - '5'
-  - '4'
 before_install:
   - if [[ `npm -v` != 3* ]]; then npm i -g npm@latest; fi
 before_script:

--- a/dadi/lib/model/index.js
+++ b/dadi/lib/model/index.js
@@ -596,7 +596,7 @@ Model.prototype.find = function (query, options, done) {
                     var parents = _.filter(results, function (result) {
                       return new RegExp(queryValue).test(result[queryKey]) === true
                     })
-                    
+
                     // check every parent category for any children that belong to them
                     for (var p = 0; p < parents.length; p++) {
                       var children = _.filter(results, function (result) {
@@ -604,11 +604,11 @@ Model.prototype.find = function (query, options, done) {
                           return result
                         }
                       })
-                      
+
                       var childIds = _.map(_.pluck(children, '_id'), function (id) {
                         return id.toString()
                       })
-                      
+
                       for (var i = 0; i < childIds.length; i++) {
                         ids.push(childIds[i])
                       }

--- a/dadi/lib/model/index.js
+++ b/dadi/lib/model/index.js
@@ -609,9 +609,7 @@ Model.prototype.find = function (query, options, done) {
                         return id.toString()
                       })
 
-                      for (var i = 0; i < childIds.length; i++) {
-                        ids.push(childIds[i])
-                      }
+                      ids = ids.concat(childIds)
                     }
 
                     query[collectionKey] = { '$in': ids || [] }


### PR DESCRIPTION
### Does this resolve an issue?

Fixes an issue detected by Bauer where parent categories which weren't first in Mongo's natural result order were not being checked for child category relationships.

I.E. `/1.0/example/collection?filter={"categories.parent.furl":"example"}` would fail if there were multiple categories with the `furl` of `example` and the parent category wasn't first in the natural order of results returned by Mongo.

### Description of changes proposed in this pull request

This PR changes the query composition logic to check all parent results.

### Who should review this pull request?

@jimlambie 💥 
