### PR TITLE
fix: allow POST using text content-type

### DIFF
--- a/dadi/lib/index.js
+++ b/dadi/lib/index.js
@@ -178,7 +178,28 @@ Server.prototype.start = function (done) {
     }
   })
 
-  app.use(bodyParser.json({ limit: '50mb' }))
+  app.use(bodyParser.json({ limit: '50mb',
+    type: req => {
+      if (['text/plain', 'text/plain; charset=utf-8', 'application/json'].includes(req.headers['content-type'])) {
+        let parts = req.url.split('/').filter(Boolean)
+
+        // don't allow parsing into JSON if:
+        if (
+          parts[parts.length - 1] === 'config' && // if it's a config URL
+          (parts.length === 3 || // and it's an endpoint file being posted
+          parts.includes('hooks')) // or it's a hook file being posted
+        ) {
+          return false
+        }
+
+        // else allow parsing into JSON
+        return true
+      } else {
+        // not a content-type that supports JSON
+        return false
+      }
+    }
+  }))
   app.use(bodyParser.urlencoded({ extended: true, limit: '50mb' }))
   app.use(bodyParser.text({ limit: '50mb' }))
 

--- a/test/acceptance/app.js
+++ b/test/acceptance/app.js
@@ -289,6 +289,33 @@ describe('Application', function () {
           })
       })
 
+      it('should create new documents when content-type is text/plain', function (done) {
+        var body = JSON.stringify({
+          field1: 'foo!'
+        })
+
+        var client = request(connectionString)
+
+        client
+          .post('/vtest/testdb/test-schema')
+          .set('Authorization', 'Bearer ' + bearerToken)
+          .set('content-type', 'text/plain')
+          .send(body)
+          .expect(200)
+          .end(function (err, res) {
+            if (err) return done(err)
+
+            should.exist(res.body.results)
+
+            res.body.results.should.be.Array
+            res.body.results.length.should.equal(1)
+            should.exist(res.body.results[0]._id)
+            should.exist(res.body.results[0].field1)
+            res.body.results[0].field1.should.equal('foo!')
+            done()
+          })
+      })
+
       it('should create new documents with ObjectIDs from single value', function (done) {
         var body = { field1: 'foo!', field2: 1278, field3: '55cb1658341a0a804d4dadcc' }
         var client = request(connectionString)


### PR DESCRIPTION
Unless it is an endpoint or a hook config POST

Fix #332 

