### PR TITLE
Don’t format when calling createFromComposed

### DIFF
--- a/dadi/lib/model/composer.js
+++ b/dadi/lib/model/composer.js
@@ -271,7 +271,7 @@ Composer.prototype.createOrUpdate = function (model, field, obj, req) {
         result[field] = newDoc._id.toString()
 
         return resolve(result)
-      })
+      }, null, true)
     }
   })
 }

--- a/dadi/lib/model/index.js
+++ b/dadi/lib/model/index.js
@@ -274,7 +274,6 @@ Model.prototype.create = function (documents, internals, done, req, bypassOutput
         if (!bypassOutputFormatting) {
           returnData.results = this.formatResultSetForOutput(returnData.results)
         }
-        // returnData.results = this.formatResultSetForOutput(returnData.results)
 
         return done(null, returnData)
       })

--- a/dadi/lib/model/index.js
+++ b/dadi/lib/model/index.js
@@ -153,7 +153,7 @@ Model.prototype.count = function (query, options, done) {
  * @return undefined
  * @api public
  */
-Model.prototype.create = function (documents, internals, done, req) {
+Model.prototype.create = function (documents, internals, done, req, bypassOutputFormatting) {
   debug('create %o %o', documents, internals)
 
   if (!Array.isArray(documents)) {
@@ -271,7 +271,10 @@ Model.prototype.create = function (documents, internals, done, req) {
         }
 
         // Prepare result set for output
-        returnData.results = this.formatResultSetForOutput(returnData.results)
+        if (!bypassOutputFormatting) {
+          returnData.results = this.formatResultSetForOutput(returnData.results)
+        }
+        // returnData.results = this.formatResultSetForOutput(returnData.results)
 
         return done(null, returnData)
       })

--- a/dadi/lib/model/utils.js
+++ b/dadi/lib/model/utils.js
@@ -172,7 +172,7 @@ function removeInternalFields (obj) {
   delete obj._apiVersion
 
   if (obj._composed) {
-    _.each(Object.keys(obj._composed), (key) => {
+    Object.keys(obj._composed).forEach(key => {
       obj[key] = obj._composed[key]
     })
 


### PR DESCRIPTION
When using reference fields, the composition module must be able to create new documents from a pre-composed document. When using an internal field prefix other than the default of `_`, this fails as the document returned to the composition module has already been formatted for output, and has no identifier === `_id` 