### PR TITLE
Read settings.internalProperties from data connectors

### DIFF
--- a/dadi/lib/datastore/index.js
+++ b/dadi/lib/datastore/index.js
@@ -11,8 +11,11 @@ const DataStore = function (storeName) {
 
   try {
     const DataStore = require(store)
+    const instance = new DataStore()
 
-    return new DataStore()
+    instance.settings = DataStore.settings || {}
+
+    return instance
   } catch (err) {
     if (err.message.indexOf('Cannot find module') > -1) {
       console.error('\n  Error: API configured to use a datastore that has not been installed: "' + store + '"\n')

--- a/dadi/lib/model/connection.js
+++ b/dadi/lib/model/connection.js
@@ -37,6 +37,10 @@ const Connection = function (options, storeName) {
     retries: config.get('databaseConnection.maxRetries')
   })
 
+  if (this.datastore.settings.connectWithCollection !== true) {
+    delete options.collection
+  }
+
   // Setting up the reconnect method
   this.recovery.on('reconnect', opts => {
     this.connect(options).then(db => {

--- a/dadi/lib/model/connection.js
+++ b/dadi/lib/model/connection.js
@@ -37,7 +37,10 @@ const Connection = function (options, storeName) {
     retries: config.get('databaseConnection.maxRetries')
   })
 
-  if (this.datastore.settings.connectWithCollection !== true) {
+  if (
+    options &&
+    this.datastore.settings.connectWithCollection !== true
+  ) {
     delete options.collection
   }
 

--- a/dadi/lib/model/history.js
+++ b/dadi/lib/model/history.js
@@ -11,12 +11,13 @@ History.prototype.create = function (obj, model, done) {
   let revisionObj = queryUtils.snapshot(obj)
   revisionObj._originalDocumentId = obj._id
 
-  // TODO: use datastore plugin's internal fields
-  delete revisionObj._id
-  delete revisionObj.meta
-  delete revisionObj.$loki
-
   const _done = function (database) {
+    if (Array.isArray(database.settings.internalProperties)) {
+      database.settings.internalProperties.forEach(property => {
+        delete revisionObj[property]
+      })
+    }
+
     database.insert({
       data: revisionObj,
       collection: model.revisionCollection,

--- a/dadi/lib/model/index.js
+++ b/dadi/lib/model/index.js
@@ -746,6 +746,7 @@ Model.prototype.formatResultSet = function (results, formatForInput) {
   let newResultSet = []
 
   documents.forEach(document => {
+    const internalProperties = this.connection.db.settings.internalProperties || []
     let newDocument = {}
 
     Object.keys(document).sort().forEach(field => {
@@ -754,9 +755,16 @@ Model.prototype.formatResultSet = function (results, formatForInput) {
         : field
 
       // Stripping null values from the response.
-      if (document[field] !== null) {
-        newDocument[property] = document[field]
+      if (document[field] === null) {
+        return
       }
+
+      // Stripping internal properties (other than `_id`)
+      if ((field !== '_id') && internalProperties.includes(field)) {
+        return
+      }
+
+      newDocument[property] = document[field]
     })
 
     newResultSet.push(newDocument)

--- a/dadi/lib/model/validator.js
+++ b/dadi/lib/model/validator.js
@@ -20,7 +20,7 @@ var ignoredKeys = _.union(
     '_lastModifiedAt',
     '_lastModifiedBy'
   ],
-  datastore.nonValidatedProperties || []
+  datastore.settings.internalProperties || []
 )
 
 var Validator = function (model) {


### PR DESCRIPTION
This PR makes API read the `internalProperties` array from the optional `settings` block of data connectors. Properties in this array will be removed from documents before inserting into history collections. They will also bypass validation.