### PR TITLE
feat: make clearing cache on POST/PUT/DELETE non-blocking

### DIFF
--- a/dadi/lib/controller/index.js
+++ b/dadi/lib/controller/index.js
@@ -213,39 +213,39 @@ Controller.prototype.post = function (req, res, next) {
   debug('POST %s %o', pathname, req.params)
 
   // flush cache for POST requests
-  help.clearCache(pathname, (err) => {
-    if (err) return next(err)
+  help.clearCache(pathname, (err) => {})
 
-    // if id is present in the url, then this is an update
-    if (req.params.id || req.body.update) {
-      internals._lastModifiedAt = Date.now()
-      internals._lastModifiedBy = req.client && req.client.clientId
+  if (err) return next(err)
 
-      var query = {}
-      var update = {}
+  // if id is present in the url, then this is an update
+  if (req.params.id || req.body.update) {
+    internals._lastModifiedAt = Date.now()
+    internals._lastModifiedBy = req.client && req.client.clientId
 
-      if (req.params.id) {
-        query._id = req.params.id
-        update = req.body
-      } else {
-        query = req.body.query
-        update = req.body.update
-      }
+    var query = {}
+    var update = {}
 
-      // add the apiVersion filter
-      if (config.get('query.useVersionFilter')) {
-        query._apiVersion = internals._apiVersion
-      }
-
-      return self.model.update(query, update, internals, sendBackJSON(200, res, next), req)
+    if (req.params.id) {
+      query._id = req.params.id
+      update = req.body
+    } else {
+      query = req.body.query
+      update = req.body.update
     }
 
-    // if no id is present, then this is a create
-    internals._createdAt = Date.now()
-    internals._createdBy = req.client && req.client.clientId
+    // add the apiVersion filter
+    if (config.get('query.useVersionFilter')) {
+      query._apiVersion = internals._apiVersion
+    }
 
-    self.model.create(req.body, internals, sendBackJSON(200, res, next), req)
-  })
+    return self.model.update(query, update, internals, sendBackJSON(200, res, next), req)
+  }
+
+  // if no id is present, then this is a create
+  internals._createdAt = Date.now()
+  internals._createdBy = req.client && req.client.clientId
+
+  self.model.create(req.body, internals, sendBackJSON(200, res, next), req)
 }
 
 Controller.prototype.put = function (req, res, next) {
@@ -266,27 +266,27 @@ Controller.prototype.delete = function (req, res, next) {
   pathname = pathname.replace('/' + req.params.id, '')
 
   // flush cache for DELETE requests
-  help.clearCache(pathname, function (err) {
+  help.clearCache(pathname, (err) => {})
+
+  if (err) return next(err)
+
+  self.model.delete(query, function (err, results) {
     if (err) return next(err)
 
-    self.model.delete(query, function (err, results) {
-      if (err) return next(err)
+    if (config.get('feedback')) {
+      // send 200 with json message
+      return help.sendBackJSON(200, res, next)(null, {
+        status: 'success',
+        message: 'Documents deleted successfully',
+        deleted: results.deletedCount,
+        totalCount: results.totalCount
+      })
+    }
 
-      if (config.get('feedback')) {
-        // send 200 with json message
-        return help.sendBackJSON(200, res, next)(null, {
-          status: 'success',
-          message: 'Documents deleted successfully',
-          deleted: results.deletedCount,
-          totalCount: results.totalCount
-        })
-      }
-
-      // send no-content success
-      res.statusCode = 204
-      res.end()
-    }, req)
-  })
+    // send no-content success
+    res.statusCode = 204
+    res.end()
+  }, req)
 }
 
 Controller.prototype.stats = function (req, res, next) {

--- a/dadi/lib/controller/index.js
+++ b/dadi/lib/controller/index.js
@@ -213,9 +213,7 @@ Controller.prototype.post = function (req, res, next) {
   debug('POST %s %o', pathname, req.params)
 
   // flush cache for POST requests
-  help.clearCache(pathname, (err) => {})
-
-  if (err) return next(err)
+  help.clearCache(pathname, () => {})
 
   // if id is present in the url, then this is an update
   if (req.params.id || req.body.update) {
@@ -266,9 +264,7 @@ Controller.prototype.delete = function (req, res, next) {
   pathname = pathname.replace('/' + req.params.id, '')
 
   // flush cache for DELETE requests
-  help.clearCache(pathname, (err) => {})
-
-  if (err) return next(err)
+  help.clearCache(pathname, () => {})
 
   self.model.delete(query, function (err, results) {
     if (err) return next(err)


### PR DESCRIPTION
This PR makes a change to the way that the cache is cleared on POST/PUT/DELETE requests. Previously, the action was blocking, but this simply makes it non-blocking. This should increase the performance of these requests, while relegating the clearing of a cache item to a less critical stage.

🎁 ➡️ @jimlambie 

The patch for `2.2.x` can be found here https://github.com/dadi/api/pull/380