### PR TITLE
(2.2.x) feat: make clearing cache on POST/PUT/DELETE non-blocking

### DIFF
--- a/dadi/lib/controller/index.js
+++ b/dadi/lib/controller/index.js
@@ -206,39 +206,39 @@ Controller.prototype.post = function (req, res, next) {
   pathname = pathname.replace('/' + req.params.id, '')
 
   // flush cache for POST requests
-  help.clearCache(pathname, (err) => {
-    if (err) return next(err)
+  help.clearCache(pathname, (err) => {})
 
-    // if id is present in the url, then this is an update
-    if (req.params.id || req.body.update) {
-      internals.lastModifiedAt = Date.now()
-      internals.lastModifiedBy = req.client && req.client.clientId
+  if (err) return next(err)
 
-      var query = {}
-      var update = {}
+  // if id is present in the url, then this is an update
+  if (req.params.id || req.body.update) {
+    internals.lastModifiedAt = Date.now()
+    internals.lastModifiedBy = req.client && req.client.clientId
 
-      if (req.params.id) {
-        query._id = req.params.id
-        update = req.body
-      } else {
-        query = req.body.query
-        update = req.body.update
-      }
+    var query = {}
+    var update = {}
 
-      // add the apiVersion filter
-      if (config.get('query.useVersionFilter')) {
-        query.apiVersion = internals.apiVersion
-      }
-
-      return self.model.update(query, update, internals, sendBackJSON(200, res, next), req)
+    if (req.params.id) {
+      query._id = req.params.id
+      update = req.body
+    } else {
+      query = req.body.query
+      update = req.body.update
     }
 
-    // if no id is present, then this is a create
-    internals.createdAt = Date.now()
-    internals.createdBy = req.client && req.client.clientId
+    // add the apiVersion filter
+    if (config.get('query.useVersionFilter')) {
+      query.apiVersion = internals.apiVersion
+    }
 
-    self.model.create(req.body, internals, sendBackJSON(200, res, next), req)
-  })
+    return self.model.update(query, update, internals, sendBackJSON(200, res, next), req)
+  }
+
+  // if no id is present, then this is a create
+  internals.createdAt = Date.now()
+  internals.createdBy = req.client && req.client.clientId
+
+  self.model.create(req.body, internals, sendBackJSON(200, res, next), req)
 }
 
 Controller.prototype.put = function (req, res, next) {
@@ -259,25 +259,25 @@ Controller.prototype.delete = function (req, res, next) {
   pathname = pathname.replace('/' + req.params.id, '')
 
   // flush cache for DELETE requests
-  help.clearCache(pathname, function (err) {
+  help.clearCache(pathname, (err) => {})
+
+  if (err) return next(err)
+
+  self.model.delete(query, function (err, results) {
     if (err) return next(err)
 
-    self.model.delete(query, function (err, results) {
-      if (err) return next(err)
+    if (config.get('feedback')) {
+      // send 200 with json message
+      return help.sendBackJSON(200, res, next)(null, {
+        status: 'success',
+        message: 'Documents deleted successfully'
+      })
+    }
 
-      if (config.get('feedback')) {
-        // send 200 with json message
-        return help.sendBackJSON(200, res, next)(null, {
-          status: 'success',
-          message: 'Documents deleted successfully'
-        })
-      }
-
-      // send no-content success
-      res.statusCode = 204
-      res.end()
-    }, req)
-  })
+    // send no-content success
+    res.statusCode = 204
+    res.end()
+  }, req)
 }
 
 Controller.prototype.stats = function (req, res, next) {

--- a/dadi/lib/controller/index.js
+++ b/dadi/lib/controller/index.js
@@ -206,9 +206,7 @@ Controller.prototype.post = function (req, res, next) {
   pathname = pathname.replace('/' + req.params.id, '')
 
   // flush cache for POST requests
-  help.clearCache(pathname, (err) => {})
-
-  if (err) return next(err)
+  help.clearCache(pathname, () => {})
 
   // if id is present in the url, then this is an update
   if (req.params.id || req.body.update) {
@@ -259,9 +257,7 @@ Controller.prototype.delete = function (req, res, next) {
   pathname = pathname.replace('/' + req.params.id, '')
 
   // flush cache for DELETE requests
-  help.clearCache(pathname, (err) => {})
-
-  if (err) return next(err)
+  help.clearCache(pathname, () => {})
 
   self.model.delete(query, function (err, results) {
     if (err) return next(err)


### PR DESCRIPTION
This PR makes a change to the way that the cache is cleared on POST/PUT/DELETE requests. Previously, the action was blocking, but this simply makes it non-blocking. This should increase the performance of these requests, while relegating the clearing of a cache item to a less critical stage.

🎁 ➡️ @jimlambie 

The patch for `develop` can be found here https://github.com/dadi/api/pull/379