### PR TITLE
feat: allow optional options to be passed to @dadi/logger

### DIFF
--- a/dadi/lib/index.js
+++ b/dadi/lib/index.js
@@ -50,6 +50,12 @@ var Server = function () {
   this.docs = {}
 }
 
+Server.prototype.initialiseLog = function (options) {
+  var logOptions = deepmerge(config.get('logging'), options && options.logging || {})
+  log.init(logOptions, {}, process.env.NODE_ENV)
+  log.info({module: 'server'}, 'Server logging started.')
+}
+
 Server.prototype.run = function (options, done) {
   require('console-stamp')(console, 'yyyy-mm-dd HH:MM:ss.l')
 
@@ -58,9 +64,7 @@ Server.prototype.run = function (options, done) {
     options = {}
   }
 
-  var logOptions = deepmerge(config.get('logging'), options && options.logging || {})
-  log.init(logOptions, {}, process.env.NODE_ENV)
-  log.info({module: 'server'}, 'Server logging started.')
+  this.initialiseLog(options)
 
   if (config.get('cluster')) {
     if (cluster.isMaster) {
@@ -158,6 +162,8 @@ Server.prototype.run = function (options, done) {
 Server.prototype.start = function (done) {
   var self = this
   this.readyState = 2
+
+  this.initialiseLog()
 
   var defaultPaths = {
     collections: path.join(__dirname, '/../../workspace/collections'),

--- a/dadi/lib/index.js
+++ b/dadi/lib/index.js
@@ -14,6 +14,7 @@ var mkdirp = require('mkdirp')
 var path = require('path')
 var pathToRegexp = require('path-to-regexp')
 var stackTrace = require('stack-trace')
+var deepmerge = require('deepmerge')
 var url = require('url')
 var _ = require('underscore')
 
@@ -57,7 +58,7 @@ Server.prototype.run = function (options, done) {
     options = {}
   }
 
-  var logOptions = Object.assign({}, config.get('logging'), options && options.logging || {})
+  var logOptions = deepmerge(config.get('logging'), options && options.logging || {})
   log.init(logOptions, {}, process.env.NODE_ENV)
   log.info({module: 'server'}, 'Server logging started.')
 

--- a/dadi/lib/index.js
+++ b/dadi/lib/index.js
@@ -35,8 +35,6 @@ var search = require(path.join(__dirname, '/search'))
 var config = require(path.join(__dirname, '/../../config'))
 var configPath = path.resolve(config.configPath())
 
-log.init(config.get('logging'), {}, process.env.NODE_ENV)
-
 if (config.get('env') !== 'test') {
   // add timestamps in front of log messages
   require('console-stamp')(console, 'yyyy-mm-dd HH:MM:ss.l')
@@ -49,12 +47,19 @@ var Server = function () {
   this.components = {}
   this.monitors = {}
   this.docs = {}
-
-  log.info({module: 'server'}, 'Server logging started.')
 }
 
-Server.prototype.run = function (done) {
+Server.prototype.run = function (options, done) {
   require('console-stamp')(console, 'yyyy-mm-dd HH:MM:ss.l')
+
+  if (typeof options === 'function' && typeof done === undefined) {
+    done = options
+    options = {}
+  }
+
+  var logOptions = Object.assign({}, config.get('logging'), options && options.logging || {})
+  log.init(logOptions, {}, process.env.NODE_ENV)
+  log.info({module: 'server'}, 'Server logging started.')
 
   if (config.get('cluster')) {
     if (cluster.isMaster) {

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "concat-stream": "^1.6.0",
     "console-stamp": "^0.2.0",
     "convict": "3.0.0",
+    "deepmerge": "^2.0.1",
     "fs-extra": "^3.0.1",
     "imagesize": "^1.0.0",
     "jsonwebtoken": "^7.4.x",

--- a/test/acceptance/cache.js
+++ b/test/acceptance/cache.js
@@ -1,70 +1,68 @@
-var crypto = require('crypto');
-var fs = require('fs');
-var path = require('path');
-var should = require('should');
-var request = require('supertest');
-//var redis = require('redis');
-var fakeredis = require('fakeredis');
-var sinon = require('sinon');
-var proxyquire =  require('proxyquire');
-var url =  require('url');
-var _ = require('underscore');
+var crypto = require('crypto')
+var fs = require('fs')
+var path = require('path')
+var should = require('should')
+var request = require('supertest')
+// var redis = require('redis');
+var fakeredis = require('fakeredis')
+var sinon = require('sinon')
+var proxyquire = require('proxyquire')
+var url = require('url')
+var _ = require('underscore')
 
-var config = require(__dirname + '/../../config.js');
-var app = require(__dirname + '/../../dadi/lib/');
-var api = require(__dirname + '/../../dadi/lib/api');
-var Server = require(__dirname + '/../../dadi/lib');
-var cache = require(__dirname + '/../../dadi/lib/cache');
-var help = require(__dirname + '/help');
+var config = require(__dirname + '/../../config.js')
+var app = require(__dirname + '/../../dadi/lib/')
+var api = require(__dirname + '/../../dadi/lib/api')
+var Server = require(__dirname + '/../../dadi/lib')
+var cache = require(__dirname + '/../../dadi/lib/cache')
+var help = require(__dirname + '/help')
 
-var testConfigString;
+var testConfigString
 var cacheKeys = []
-var bearerToken;
+var bearerToken
 
 describe('Cache', function (done) {
   this.timeout(4000)
 
-  after(function(done) {
-    testConfigString = fs.readFileSync(config.configPath());
+  after(function (done) {
+    testConfigString = fs.readFileSync(config.configPath())
 
-    var newTestConfig = JSON.parse(testConfigString);
-    newTestConfig.caching.directory.enabled = true;
-    newTestConfig.caching.redis.enabled = false;
-    fs.writeFileSync(config.configPath(), JSON.stringify(newTestConfig, null, 2));
-    done();
-  });
+    var newTestConfig = JSON.parse(testConfigString)
+    newTestConfig.caching.directory.enabled = true
+    newTestConfig.caching.redis.enabled = false
+    fs.writeFileSync(config.configPath(), JSON.stringify(newTestConfig, null, 2))
+    done()
+  })
 
-  beforeEach(function(done) {
+  beforeEach(function (done) {
     try {
       cache.reset()
-      app.stop(function(){});
-      done();
+      app.stop(function () {})
+      done()
+    } catch (err) {
+      done()
     }
-    catch (err) {
-      done();
-    }
-  });
+  })
 
   it('should use cache if available', function (done) {
-    app.start(function() {
+    app.start(function () {
       help.dropDatabase('test', function (err) {
-        if (err) return done(err);
+        if (err) return done(err)
 
         help.getBearerToken(function (err, token) {
-          if (err) return done(err);
+          if (err) return done(err)
 
-          bearerToken = token;
-          help.clearCache();
+          bearerToken = token
+          help.clearCache()
 
-          var client = request('http://' + config.get('server.host') + ':' + config.get('server.port'));
+          var client = request('http://' + config.get('server.host') + ':' + config.get('server.port'))
 
           client
           .get('/vtest/testdb/test-schema')
           .set('Authorization', 'Bearer ' + bearerToken)
           .expect(200)
           .end(function (err, res1) {
-            if (err) return done(err);
-
+            if (err) return done(err)
 
             client
             .post('/vtest/testdb/test-schema')
@@ -72,52 +70,52 @@ describe('Cache', function (done) {
             .send({field1: 'foo!'})
             .expect(200)
             .end(function (err, res) {
-              if (err) return done(err);
+              if (err) return done(err)
 
               client
               .get('/vtest/testdb/test-schema')
               .set('Authorization', 'Bearer ' + bearerToken)
               .expect(200)
               .end(function (err, res2) {
-                if (err) return done(err);
+                if (err) return done(err)
 
                 client
                 .get('/vtest/testdb/test-schema')
                 .set('Authorization', 'Bearer ' + bearerToken)
                 .expect(200)
                 .end(function (err, res3) {
-                  if (err) return done(err);
+                  if (err) return done(err)
 
-                  res2.text.should.equal(res3.text);
+                  res2.text.should.equal(res3.text)
 
                   should.exist(res3.headers['x-cache'])
                   res3.headers['x-cache'].should.eql('HIT')
 
-                  help.removeTestClients(function() {
-                    help.clearCache();
-                    app.stop(done);
-                  });
-                });
-              });
-            });
-          });
-        });
-      });
-    });
-  });
+                  help.removeTestClients(function () {
+                    help.clearCache()
+                    app.stop(done)
+                  })
+                })
+              })
+            })
+          })
+        })
+      })
+    })
+  })
 
   it('should allow bypassing cache with query string flag', function (done) {
-    app.start(function() {
+    app.start(function () {
       help.dropDatabase('test', function (err) {
-        if (err) return done(err);
+        if (err) return done(err)
 
         help.getBearerToken(function (err, token) {
-          if (err) return done(err);
+          if (err) return done(err)
 
-          bearerToken = token;
-          help.clearCache();
+          bearerToken = token
+          help.clearCache()
 
-          var client = request('http://' + config.get('server.host') + ':' + config.get('server.port'));
+          var client = request('http://' + config.get('server.host') + ':' + config.get('server.port'))
 
           client
           .post('/vtest/testdb/test-schema')
@@ -125,77 +123,77 @@ describe('Cache', function (done) {
           .send({field1: 'foo!'})
           .expect(200)
           .end(function (err, res) {
-            if (err) return done(err);
+            if (err) return done(err)
 
             client
             .get('/vtest/testdb/test-schema')
             .set('Authorization', 'Bearer ' + bearerToken)
             .expect(200)
             .end(function (err, res1) {
-              if (err) return done(err);
+              if (err) return done(err)
 
-              res1.body['results'].length.should.equal(1);
+              res1.body['results'].length.should.equal(1)
 
               client
               .get('/vtest/testdb/test-schema?cache=false')
               .set('Authorization', 'Bearer ' + bearerToken)
               .expect(200)
               .end(function (err, res2) {
-                if (err) return done(err);
+                if (err) return done(err)
 
-                should.exist(res2.headers['x-cache']);
-                res2.headers['x-cache'].should.eql('MISS');
-                should.exist(res2.headers['x-cache-lookup']);
-                res2.headers['x-cache-lookup'].should.eql('HIT');
+                should.exist(res2.headers['x-cache'])
+                res2.headers['x-cache'].should.eql('MISS')
+                should.exist(res2.headers['x-cache-lookup'])
+                res2.headers['x-cache-lookup'].should.eql('HIT')
 
-                help.removeTestClients(function() {
-                  help.clearCache();
-                  app.stop(done);
-                });
-              });
-            });
-          });
-        });
-      });
-    });
-  });
+                help.removeTestClients(function () {
+                  help.clearCache()
+                  app.stop(done)
+                })
+              })
+            })
+          })
+        })
+      })
+    })
+  })
 
   it('should allow disabling through config', function (done) {
-    testConfigString = fs.readFileSync(config.configPath());
+    testConfigString = fs.readFileSync(config.configPath())
 
-    var newTestConfig = JSON.parse(testConfigString);
-    newTestConfig.caching.directory.enabled = false;
-    newTestConfig.caching.redis.enabled = false;
+    var newTestConfig = JSON.parse(testConfigString)
+    newTestConfig.caching.directory.enabled = false
+    newTestConfig.caching.redis.enabled = false
 
-    fs.writeFileSync(config.configPath(), JSON.stringify(newTestConfig, null, 2));
+    fs.writeFileSync(config.configPath(), JSON.stringify(newTestConfig, null, 2))
 
-    cache.reset();
+    cache.reset()
 
-    delete require.cache[__dirname + '/../../config'];
-    delete require.cache[__dirname + '/../../dadi/lib/'];
-    config = require(__dirname + '/../../config');
-    config.loadFile(config.configPath());
+    delete require.cache[__dirname + '/../../config']
+    delete require.cache[__dirname + '/../../dadi/lib/']
+    config = require(__dirname + '/../../config')
+    config.loadFile(config.configPath())
 
-    var spy = sinon.spy(fs, 'createWriteStream');
+    var spy = sinon.spy(fs, 'createWriteStream')
 
-    app.start(function() {
+    app.start(function () {
       help.dropDatabase('test', function (err) {
-        if (err) return done(err);
-      help.getBearerToken(function (err, token) {
-         if (err) return done(err);
-         bearerToken = token;
-         help.clearCache();
+        if (err) return done(err)
+        help.getBearerToken(function (err, token) {
+          if (err) return done(err)
+          bearerToken = token
+          help.clearCache()
 
-        var client = request('http://' + config.get('server.host') + ':' + config.get('server.port'));
+          var client = request('http://' + config.get('server.host') + ':' + config.get('server.port'))
 
-        client
+          client
         .get('/vtest/testdb/test-schema')
         .set('Authorization', 'Bearer ' + bearerToken)
         .expect(200)
         .end(function (err, res1) {
-          if (err) return done(err);
+          if (err) return done(err)
 
-          res1.body['results'].length.should.equal(0);
+          res1.body['results'].length.should.equal(0)
 
           client
           .post('/vtest/testdb/test-schema')
@@ -203,39 +201,42 @@ describe('Cache', function (done) {
           .send({field1: 'foo!'})
           .expect(200)
           .end(function (err, res) {
-            if (err) return done(err);
+            if (err) return done(err)
 
             client
             .get('/vtest/testdb/test-schema')
             .set('Authorization', 'Bearer ' + bearerToken)
             .expect(200)
             .end(function (err, res2) {
-              if (err) return done(err);
+              if (err) return done(err)
 
+              res2.body['results'].length.should.equal(1)
 
-              res2.body['results'].length.should.equal(1);
+              var args = spy.args
 
-              var called = spy.called;
-              spy.restore();
-              called.should.be.false;
+              spy.restore()
 
-              fs.writeFileSync(config.configPath(), testConfigString);
-              cache.reset();
-              delete require.cache[__dirname + '/../../config'];
-              config = require(__dirname + '/../../config');
-              config.loadFile(config.configPath());
+              args.forEach(arg => {
+                arg[0].should.not.eql(config.configPath())
+              })
 
-              app.stop(function(){});
-              done();
-            });
-          });
-        });
-        });
-      });
-    });
-  });
+              fs.writeFileSync(config.configPath(), testConfigString)
+              cache.reset()
+              delete require.cache[__dirname + '/../../config']
+              config = require(__dirname + '/../../config')
+              config.loadFile(config.configPath())
 
-  describe('Filesystem', function(done) {
+              app.stop(function () {})
+              done()
+            })
+          })
+        })
+        })
+      })
+    })
+  })
+
+  describe('Filesystem', function (done) {
     beforeEach(function (done) {
       var testConfigString = fs.readFileSync(config.configPath())
 
@@ -249,116 +250,114 @@ describe('Cache', function (done) {
 
       config.loadFile(config.configPath())
 
-      app.start(function() {
+      app.start(function () {
         help.dropDatabase('test', function (err) {
-          if (err) return done(err);
+          if (err) return done(err)
 
           help.getBearerToken(function (err, token) {
-            if (err) return done(err);
+            if (err) return done(err)
 
-            bearerToken = token;
-            help.clearCache();
-            done();
-          });
-        });
-      });
-    });
+            bearerToken = token
+            help.clearCache()
+            done()
+          })
+        })
+      })
+    })
 
     afterEach(function (done) {
-      help.removeTestClients(function() {
-        //help.clearCache();
-        app.stop(done);
-      });
-    });
+      help.removeTestClients(function () {
+        // help.clearCache();
+        app.stop(done)
+      })
+    })
 
     it('should save responses to the file system', function (done) {
-      var spy = sinon.spy(fs, 'createWriteStream');
+      var spy = sinon.spy(fs, 'createWriteStream')
 
       request('http://' + config.get('server.host') + ':' + config.get('server.port'))
       .get('/vtest/testdb/test-schema')
       .set('Authorization', 'Bearer ' + bearerToken)
       .expect(200)
       .end(function (err, res) {
-        if (err) return done(err);
+        if (err) return done(err)
 
-        setTimeout(function() {
-          spy.called.should.be.true;
-          var args = spy.getCall(0).args;
+        setTimeout(function () {
+          spy.called.should.be.true
+          var args = spy.getCall(0).args
 
-          args[0].indexOf('cache/api').should.be.above(-1);
+          args[0].indexOf('cache/api').should.be.above(-1)
 
-          spy.restore();
-          done();
-
-        }, 1000);
-      });
-    });
+          spy.restore()
+          done()
+        }, 1000)
+      })
+    })
 
     it('should invalidate based on TTL', function (done) {
-      this.timeout(4000);
+      this.timeout(4000)
 
-      var oldTTL = config.get('caching.ttl');
-      config.set('caching.ttl', 1);
+      var oldTTL = config.get('caching.ttl')
+      config.set('caching.ttl', 1)
 
-      var _done = done;
+      var _done = done
       done = function (err) {
-        config.set('caching.ttl', oldTTL);
-        _done(err);
-      };
+        config.set('caching.ttl', oldTTL)
+        _done(err)
+      }
 
-      var client = request('http://' + config.get('server.host') + ':' + config.get('server.port'));
+      var client = request('http://' + config.get('server.host') + ':' + config.get('server.port'))
 
       client
       .get('/vtest/testdb/test-schema')
       .set('Authorization', 'Bearer ' + bearerToken)
       .expect(200)
       .end(function (err, res1) {
-        if (err) return done(err);
+        if (err) return done(err)
         client
         .post('/vtest/testdb/test-schema')
         .set('Authorization', 'Bearer ' + bearerToken)
         .send({field1: 'foo!'})
         .expect(200)
         .end(function (err, res) {
-          if (err) return done(err);
+          if (err) return done(err)
 
           setTimeout(function () {
-
             // ttl should have expired
             client
             .get('/vtest/testdb/test-schema')
             .set('Authorization', 'Bearer ' + bearerToken)
             .expect(200)
             .end(function (err, res2) {
-              if (err) return done(err);
+              if (err) return done(err)
 
-              res1.body['results'].length.should.equal(0);
-              res2.body['results'].length.should.equal(1);
-              res2.text.should.not.equal(res1.text);
+              res1.body['results'].length.should.equal(0)
+              res2.body['results'].length.should.equal(1)
+              res2.text.should.not.equal(res1.text)
 
-              done();
-            });
-          }, 1000);
-        });
-      });
-    });
+              done()
+            })
+          }, 1000)
+        })
+      })
+    })
 
     it('should flush on POST create request', function (done) {
-  	  this.timeout(4000);
+      this.timeout(4000)
       help.createDoc(bearerToken, function (err, doc) {
-        if (err) return done(err);
+        if (err) return done(err)
 
         help.createDoc(bearerToken, function (err, doc) {
-          if (err) return done(err);
+          if (err) return done(err)
 
-          var client = request('http://' + config.get('server.host') + ':' + config.get('server.port'));
+          var client = request('http://' + config.get('server.host') + ':' + config.get('server.port'))
 
           client
           .get('/vtest/testdb/test-schema')
           .set('Authorization', 'Bearer ' + bearerToken)
           .expect(200)
           .end(function (err, res1) {
-            if (err) return done(err);
+            if (err) return done(err)
 
             client
             .post('/vtest/testdb/test-schema')
@@ -366,40 +365,39 @@ describe('Cache', function (done) {
             .send({field1: 'foo!'})
             .expect(200)
             .end(function (err, res2) {
-              if (err) return done(err);
+              if (err) return done(err)
 
               setTimeout(function () {
-
                 client
                 .get('/vtest/testdb/test-schema')
                 .set('Authorization', 'Bearer ' + bearerToken)
                 .expect(200)
                 .end(function (err, res3) {
-                  if (err) return done(err);
+                  if (err) return done(err)
 
-                  res1.body.results.length.should.eql(2);
-                  res3.body.results.length.should.eql(3);
-                  res3.text.should.not.equal(res1.text);
+                  res1.body.results.length.should.eql(2)
+                  res3.body.results.length.should.eql(3)
+                  res3.text.should.not.equal(res1.text)
 
-                  done();
-                });
-              }, 300);
-            });
-          });
-        });
-      });
-    });
+                  done()
+                })
+              }, 300)
+            })
+          })
+        })
+      })
+    })
 
     it('should flush on PUT update request', function (done) {
-  	   this.timeout(4000);
+      this.timeout(4000)
 
       help.createDoc(bearerToken, function (err, doc) {
-        if (err) return done(err);
+        if (err) return done(err)
 
         help.createDoc(bearerToken, function (err, doc) {
-          if (err) return done(err);
+          if (err) return done(err)
 
-          var client = request('http://' + config.get('server.host') + ':' + config.get('server.port'));
+          var client = request('http://' + config.get('server.host') + ':' + config.get('server.port'))
 
           // GET
           client
@@ -407,7 +405,7 @@ describe('Cache', function (done) {
           .set('Authorization', 'Bearer ' + bearerToken)
           .expect(200)
           .end(function (err, getRes1) {
-            if (err) return done(err);
+            if (err) return done(err)
 
             // CREATE
             client
@@ -416,10 +414,10 @@ describe('Cache', function (done) {
             .send({field1: 'foo!'})
             .expect(200)
             .end(function (err, postRes1) {
-              if (err) return done(err);
+              if (err) return done(err)
 
               // save id for updating
-              var id = postRes1.body.results[0]._id;
+              var id = postRes1.body.results[0]._id
 
               // GET AGAIN - should cache new results
               client
@@ -427,10 +425,9 @@ describe('Cache', function (done) {
               .set('Authorization', 'Bearer ' + bearerToken)
               .expect(200)
               .end(function (err, getRes2) {
-                if (err) return done(err);
+                if (err) return done(err)
 
                 setTimeout(function () {
-
                   // UPDATE again
                   client
                   .put('/vtest/testdb/test-schema/' + id)
@@ -438,43 +435,42 @@ describe('Cache', function (done) {
                   .send({field1: 'foo bar baz!'})
                   .expect(200)
                   .end(function (err, postRes2) {
-                    if (err) return done(err);
+                    if (err) return done(err)
 
                     // WAIT, then GET again
                     setTimeout(function () {
-
                       client
                       .get('/vtest/testdb/test-schema')
                       .set('Authorization', 'Bearer ' + bearerToken)
                       .expect(200)
                       .end(function (err, getRes3) {
-                        if (err) return done(err);
+                        if (err) return done(err)
 
-                        var result = _.findWhere(getRes3.body.results, { "_id": id });
+                        var result = _.findWhere(getRes3.body.results, { '_id': id })
 
-                        result.field1.should.eql('foo bar baz!');
+                        result.field1.should.eql('foo bar baz!')
 
-                        done();
-                      });
-                    }, 200);
-                  });
-                }, 300);
-              });
-            });
-          });
-        });
-      });
-    });
+                        done()
+                      })
+                    }, 200)
+                  })
+                }, 300)
+              })
+            })
+          })
+        })
+      })
+    })
 
     it('should flush on DELETE request', function (done) {
-  	  this.timeout(4000);
+      this.timeout(4000)
       help.createDoc(bearerToken, function (err, doc) {
-        if (err) return done(err);
+        if (err) return done(err)
 
         help.createDoc(bearerToken, function (err, doc) {
-          if (err) return done(err);
+          if (err) return done(err)
 
-          var client = request('http://' + config.get('server.host') + ':' + config.get('server.port'));
+          var client = request('http://' + config.get('server.host') + ':' + config.get('server.port'))
 
           // GET
           client
@@ -482,7 +478,7 @@ describe('Cache', function (done) {
           .set('Authorization', 'Bearer ' + bearerToken)
           .expect(200)
           .end(function (err, getRes1) {
-            if (err) return done(err);
+            if (err) return done(err)
 
             // CREATE
             client
@@ -491,10 +487,10 @@ describe('Cache', function (done) {
             .send({field1: 'foo!'})
             .expect(200)
             .end(function (err, postRes1) {
-              if (err) return done(err);
+              if (err) return done(err)
 
               // save id for deleting
-              var id = postRes1.body.results[0]._id;
+              var id = postRes1.body.results[0]._id
 
               // GET AGAIN - should cache new results
               client
@@ -502,46 +498,44 @@ describe('Cache', function (done) {
               .set('Authorization', 'Bearer ' + bearerToken)
               .expect(200)
               .end(function (err, getRes2) {
-                if (err) return done(err);
+                if (err) return done(err)
 
                 setTimeout(function () {
-
                   // DELETE
                   client
                   .delete('/vtest/testdb/test-schema/' + id)
                   .set('Authorization', 'Bearer ' + bearerToken)
                   .expect(204)
                   .end(function (err, postRes2) {
-                    if (err) return done(err);
+                    if (err) return done(err)
 
                     // WAIT, then GET again
                     setTimeout(function () {
-
                       client
                       .get('/vtest/testdb/test-schema')
                       .set('Authorization', 'Bearer ' + bearerToken)
                       .expect(200)
                       .end(function (err, getRes3) {
-                        if (err) return done(err);
+                        if (err) return done(err)
 
-                        var result = _.findWhere(getRes3.body.results, { "_id": id });
+                        var result = _.findWhere(getRes3.body.results, { '_id': id })
 
-                        should.not.exist(result);
+                        should.not.exist(result)
 
-                        done();
-                      });
-                    }, 300);
-                  });
-                }, 700);
-              });
-            });
-          });
-        });
-      });
-    });
+                        done()
+                      })
+                    }, 300)
+                  })
+                }, 700)
+              })
+            })
+          })
+        })
+      })
+    })
 
     it('should preserve content-type', function (done) {
-      var client = request('http://' + config.get('server.host') + ':' + config.get('server.port'));
+      var client = request('http://' + config.get('server.host') + ':' + config.get('server.port'))
 
       client
       .get('/vtest/testdb/test-schema?callback=myCallback')
@@ -549,7 +543,7 @@ describe('Cache', function (done) {
       .expect(200)
       .expect('content-type', 'text/javascript')
       .end(function (err, res1) {
-        if (err) return done(err);
+        if (err) return done(err)
 
         client
         .post('/vtest/testdb/test-schema')
@@ -557,7 +551,7 @@ describe('Cache', function (done) {
         .send({field1: 'foo!'})
         .expect(200)
         .end(function (err, res) {
-          if (err) return done(err);
+          if (err) return done(err)
 
           client
           .get('/vtest/testdb/test-schema?callback=myCallback')
@@ -565,17 +559,17 @@ describe('Cache', function (done) {
           .expect(200)
           .expect('content-type', 'text/javascript')
           .end(function (err, res2) {
-            if (err) return done(err);
+            if (err) return done(err)
 
-            res2.text.should.not.equal(res1.text);
-            done();
-          });
-        });
-      });
-    });
-  });
+            res2.text.should.not.equal(res1.text)
+            done()
+          })
+        })
+      })
+    })
+  })
 
-  describe('Redis', function(done) {
+  describe('Redis', function (done) {
     beforeEach(function (done) {
       testConfigString = fs.readFileSync(config.configPath())
 
@@ -595,122 +589,117 @@ describe('Cache', function (done) {
       // cache = require(__dirname + '/../../dadi/lib/cache');
       // delete require.cache[__dirname + '/../../config'];
       // config = require(__dirname + '/../../config');
-      done();
-    });
+      done()
+    })
 
-    afterEach(function(done) {
-      fs.writeFileSync(config.configPath(), testConfigString);
-      done();
-    });
+    afterEach(function (done) {
+      fs.writeFileSync(config.configPath(), testConfigString)
+      done()
+    })
 
-    it('should throw error if can\'t connect to Redis client', function(done) {
-      delete require.cache[__dirname + '/../../config.js'];
-      delete require.cache[__dirname + '/../../dadi/lib/'];
+    it('should throw error if can\'t connect to Redis client', function (done) {
+      delete require.cache[__dirname + '/../../config.js']
+      delete require.cache[__dirname + '/../../dadi/lib/']
 
-      config.loadFile(config.configPath());
-
-      try {
-        app.stop(function(){});
-        should.throws(function() { app.start(function(){}); }, Error);
-      }
-      catch (err) {
-      }
-
-      done();
-
-    });
-
-    it.skip('should initialise Redis client', function(done) {
-      delete require.cache[__dirname + '/../../config.js'];
-      config.loadFile(config.configPath());
-
-      //sinon.stub(redis, 'createClient', fakeredis.createClient);
-
-      delete require.cache[__dirname + '/../../dadi/lib/'];
-      cache.reset();
+      config.loadFile(config.configPath())
 
       try {
-        app.stop(function(){});
-        //app.start(function(){});
+        app.stop(function () {})
+        should.throws(function () { app.start(function () {}) }, Error)
+      } catch (err) {
       }
-      catch (err) {
+
+      done()
+    })
+
+    it.skip('should initialise Redis client', function (done) {
+      delete require.cache[__dirname + '/../../config.js']
+      config.loadFile(config.configPath())
+
+      // sinon.stub(redis, 'createClient', fakeredis.createClient);
+
+      delete require.cache[__dirname + '/../../dadi/lib/']
+      cache.reset()
+
+      try {
+        app.stop(function () {})
+        // app.start(function(){});
+      } catch (err) {
       }
 
-      var c = cache(app);
-      //redis.createClient.restore();
-      //c.redisClient.should.not.be.null;
-      //app.stop(function(){});
-      done();
-    });
+      var c = cache(app)
+      // redis.createClient.restore();
+      // c.redisClient.should.not.be.null;
+      // app.stop(function(){});
+      done()
+    })
 
-    it.skip('should fallback to directory cache if Redis client fails', function(done) {
-      delete require.cache[__dirname + '/../../config.js'];
-      config.loadFile(config.configPath());
+    it.skip('should fallback to directory cache if Redis client fails', function (done) {
+      delete require.cache[__dirname + '/../../config.js']
+      config.loadFile(config.configPath())
 
-      var EventEmitter = require('events');
-      var util = require('util');
+      var EventEmitter = require('events')
+      var util = require('util')
 
       /* Fake redis client */
-      function Client() {
-        this.end = function(reallyEnd) { }
-        EventEmitter.call(this);
+      function Client () {
+        this.end = function (reallyEnd) { }
+        EventEmitter.call(this)
       }
 
-      util.inherits(Client, EventEmitter);
-      var redisClient = new Client();
+      util.inherits(Client, EventEmitter)
+      var redisClient = new Client()
       /* End Fake redis client */
 
-      sinon.stub(redis, 'createClient').returns(redisClient);
+      sinon.stub(redis, 'createClient').returns(redisClient)
 
-      delete require.cache[__dirname + '/../../dadi/lib/'];
-      cache.reset();
+      delete require.cache[__dirname + '/../../dadi/lib/']
+      cache.reset()
 
-      var c = cache(app);
+      var c = cache(app)
       // redis.createClient.restore();
 
-      setTimeout(function() {
+      setTimeout(function () {
         // emit an error event
-        redisClient.emit('error', { code: 'CONNECTION_BROKEN'});
+        redisClient.emit('error', { code: 'CONNECTION_BROKEN'})
 
         config.get('caching.directory.enabled').should.eql(true)
 
         try {
-          app.stop(function(){});
-        }
-        catch (err) {
+          app.stop(function () {})
+        } catch (err) {
         }
 
-        done();
+        done()
       }, 1000)
+    })
 
-    });
-
-    it('should check key exists in Redis', function(done) {
-      delete require.cache[__dirname + '/../../config.js'];
-      config.loadFile(config.configPath());
+    it('should check key exists in Redis', function (done) {
+      delete require.cache[__dirname + '/../../config.js']
+      config.loadFile(config.configPath())
 
       delete require.cache[__dirname + '/../../dadi/lib/']
 
       cache.reset()
-      var c = cache(app);
+      var c = cache(app)
       c.cache.cacheHandler.redisClient = fakeredis.createClient()
       c.cache.cacheHandler.redisClient.status = 'ready'
       var spy = sinon.spy(c.cache.cacheHandler.redisClient, 'exists')
 
       // generate expected cacheKey
-      var requestUrl = '/vtest/testdb/test-schema';
-      var query = url.parse(requestUrl, true).query;
-      var modelDir = crypto.createHash('sha1').update(url.parse(requestUrl).pathname).digest('hex');
-      var filename = crypto.createHash('sha1').update(url.parse(requestUrl).pathname + JSON.stringify(query)).digest('hex');
-      var cacheKey = modelDir + '_' + filename;
+      var requestUrl = '/vtest/testdb/test-schema'
+      var query = url.parse(requestUrl, true).query
+      var modelDir = crypto.createHash('sha1').update(url.parse(requestUrl).pathname).digest('hex')
+      var filename = crypto.createHash('sha1').update(url.parse(requestUrl).pathname + JSON.stringify(query)).digest('hex')
+      var cacheKey = modelDir + '_' + filename
 
       try {
-        app.start(function() {
-         help.getBearerToken(function (err, token) {
-            if (err) return done(err);
-            bearerToken = token;
+        app.start(function () {
+          help.getBearerToken(function (err, token) {
+            if (err) return done(err)
+            bearerToken = token
 
-            var client = request('http://' + config.get('server.host') + ':' + config.get('server.port'));
+            var client = request('http://' + config.get('server.host') + ':' + config.get('server.port'))
 
             client
             .get(requestUrl)
@@ -719,90 +708,86 @@ describe('Cache', function (done) {
             .end(function (err, res) {
               if (err) return done(err)
 
-              spy.called.should.eql(true);
-              spy.args[0][0].should.eql(cacheKey);
+              spy.called.should.eql(true)
+              spy.args[0][0].should.eql(cacheKey)
 
               c.cache.cacheHandler.redisClient.exists.restore()
-              app.stop(function(){});
-              done();
-            });
-
-          });
-        });
-      }
-      catch (err) {
+              app.stop(function () {})
+              done()
+            })
+          })
+        })
+      } catch (err) {
         console.log(err)
-        done();
+        done()
       }
-    });
+    })
 
-    it('should return data if key exists in Redis, with correct headers', function(done) {
-      delete require.cache[__dirname + '/../../config.js'];
-      config.loadFile(config.configPath());
+    it('should return data if key exists in Redis, with correct headers', function (done) {
+      delete require.cache[__dirname + '/../../config.js']
+      config.loadFile(config.configPath())
 
-      delete require.cache[__dirname + '/../../dadi/lib/'];
+      delete require.cache[__dirname + '/../../dadi/lib/']
 
       // generate expected cacheKey
-      var requestUrl = '/vtest/testdb/test-schema';
-      var query = url.parse(requestUrl, true).query;
-      var modelDir = crypto.createHash('sha1').update(url.parse(requestUrl).pathname).digest('hex');
-      var filename = crypto.createHash('sha1').update(url.parse(requestUrl).pathname + JSON.stringify(query)).digest('hex');
-      var cacheKey = modelDir + '_' + filename;
+      var requestUrl = '/vtest/testdb/test-schema'
+      var query = url.parse(requestUrl, true).query
+      var modelDir = crypto.createHash('sha1').update(url.parse(requestUrl).pathname).digest('hex')
+      var filename = crypto.createHash('sha1').update(url.parse(requestUrl).pathname + JSON.stringify(query)).digest('hex')
+      var cacheKey = modelDir + '_' + filename
 
       cache.reset()
-      var c = cache(app);
+      var c = cache(app)
       c.cache.cacheHandler.redisClient = fakeredis.createClient()
       c.cache.cacheHandler.redisClient.status = 'ready'
       c.cache.cacheHandler.redisClient.set(cacheKey, 'DATA')
 
       try {
-        app.start(function() {
-         help.getBearerToken(function (err, token) {
-            if (err) return done(err);
-            bearerToken = token;
+        app.start(function () {
+          help.getBearerToken(function (err, token) {
+            if (err) return done(err)
+            bearerToken = token
 
-            var client = request('http://' + config.get('server.host') + ':' + config.get('server.port'));
+            var client = request('http://' + config.get('server.host') + ':' + config.get('server.port'))
 
             client
             .get(requestUrl)
             .set('Authorization', 'Bearer ' + bearerToken)
             .expect(200)
             .end(function (err, res) {
-              if (err) return done(err);
+              if (err) return done(err)
 
-              res.text.should.eql('DATA');
-              res.headers['x-cache'].should.eql('HIT');
+              res.text.should.eql('DATA')
+              res.headers['x-cache'].should.eql('HIT')
 
-              app.stop(function(){});
-              done();
-            });
-
-          });
-        });
-      }
-      catch (err) {
+              app.stop(function () {})
+              done()
+            })
+          })
+        })
+      } catch (err) {
         console.log(err)
-        done();
+        done()
       }
-    });
+    })
 
-    it('should invalidate based on TTL', function(done) {
-      this.timeout(6000);
+    it('should invalidate based on TTL', function (done) {
+      this.timeout(6000)
 
-      var configString = fs.readFileSync(config.configPath());
-      var newTestConfig = JSON.parse(configString);
-      newTestConfig.caching.ttl = 1;
-      fs.writeFileSync(config.configPath(), JSON.stringify(newTestConfig, null, 2));
-      delete require.cache[__dirname + '/../../config'];
-      //config = require(__dirname + '/../../config');
+      var configString = fs.readFileSync(config.configPath())
+      var newTestConfig = JSON.parse(configString)
+      newTestConfig.caching.ttl = 1
+      fs.writeFileSync(config.configPath(), JSON.stringify(newTestConfig, null, 2))
+      delete require.cache[__dirname + '/../../config']
+      // config = require(__dirname + '/../../config');
 
-      delete require.cache[__dirname + '/../../config.js'];
-      delete require.cache[__dirname + '/../../dadi/lib/'];
+      delete require.cache[__dirname + '/../../config.js']
+      delete require.cache[__dirname + '/../../dadi/lib/']
 
-      config.loadFile(config.configPath());
+      config.loadFile(config.configPath())
 
       cache.reset()
-      var c = cache(app);
+      var c = cache(app)
       c.cache.cacheHandler.redisClient = fakeredis.createClient()
       c.cache.cacheHandler.redisClient.status = 'ready'
 
@@ -811,7 +796,7 @@ describe('Cache', function (done) {
         var stream = new Readable({objectMode: true})
 
         for (var i = 0; i < cacheKeys.length; i++) {
-          if (pattern.match === '*' || cacheKeys[i].indexOf(pattern.match.substring(0, pattern.match.length-1)) === 0) {
+          if (pattern.match === '*' || cacheKeys[i].indexOf(pattern.match.substring(0, pattern.match.length - 1)) === 0) {
             stream.push([cacheKeys[i]])
           } else {
             // console.log('rejected key: ', cacheKeys[i])
@@ -823,15 +808,15 @@ describe('Cache', function (done) {
       }
 
       try {
-        app.start(function() {
+        app.start(function () {
           help.dropDatabase('test', function (err) {
-            if (err) return done(err);
+            if (err) return done(err)
 
-           help.getBearerToken(function (err, token) {
-              if (err) return done(err);
-              bearerToken = token;
+            help.getBearerToken(function (err, token) {
+              if (err) return done(err)
+              bearerToken = token
 
-              var client = request('http://' + config.get('server.host') + ':' + config.get('server.port'));
+              var client = request('http://' + config.get('server.host') + ':' + config.get('server.port'))
 
               client
               .post('/vtest/testdb/test-schema')
@@ -839,7 +824,7 @@ describe('Cache', function (done) {
               .send({field1: 'foo!'})
               .expect(200)
               .end(function (err, res) {
-                if (err) return done(err);
+                if (err) return done(err)
 
                 client
                 .get('/vtest/testdb/test-schema')
@@ -858,137 +843,35 @@ describe('Cache', function (done) {
                         .set('Authorization', 'Bearer ' + bearerToken)
                         .expect(200)
                         .end(function (err, res2) {
-                          if (err) return done(err);
+                          if (err) return done(err)
 
-                          res2.headers['x-cache'].should.eql('MISS');
-                          res2.headers['x-cache-lookup'].should.eql('MISS');
+                          res2.headers['x-cache'].should.eql('MISS')
+                          res2.headers['x-cache-lookup'].should.eql('MISS')
 
-                          app.stop(function(){});
-                          done();
-
-                        });
-                      }, 1500);
-                    });
-                  }, 1500);
-                });
-              });
-            });
-          });
-        });
+                          app.stop(function () {})
+                          done()
+                        })
+                      }, 1500)
+                    })
+                  }, 1500)
+                })
+              })
+            })
+          })
+        })
+      } catch (err) {
+        console.log(err)
+        done()
       }
-      catch (err) {
-        console.log(err);
-        done();
-      }
-    });
+    })
 
-    it('should flush on POST create request', function(done) {
+    it('should flush on POST create request', function (done) {
       this.timeout(8000)
 
-      delete require.cache[__dirname + '/../../config.js'];
-      delete require.cache[__dirname + '/../../dadi/lib/'];
+      delete require.cache[__dirname + '/../../config.js']
+      delete require.cache[__dirname + '/../../dadi/lib/']
 
-      config.loadFile(config.configPath());
-
-      cache.reset()
-      var c = cache(app);
-      c.cache.cacheHandler.redisClient = fakeredis.createClient()
-      c.cache.cacheHandler.redisClient.status = 'ready'
-
-      c.cache.cacheHandler.redisClient.scanStream = function (pattern) {
-        var Readable = require('stream').Readable
-        var stream = new Readable({objectMode: true})
-
-        for (var i = 0; i < cacheKeys.length; i++) {
-          if (pattern.match === '*' || cacheKeys[i].indexOf(pattern.match.substring(0, pattern.match.length-1)) === 0) {
-            stream.push([cacheKeys[i]])
-          } else {
-            // console.log('rejected key: ', cacheKeys[i])
-          }
-        }
-
-        stream.push(null)
-        return stream
-      }
-
-      try {
-        app.start(function() {
-          help.dropDatabase('test', function (err) {
-            if (err) return done(err);
-
-            help.getBearerToken(function (err, token) {
-               if (err) return done(err);
-               bearerToken = token;
-
-              help.createDoc(bearerToken, function (err, doc) {
-                if (err) return done(err);
-
-                help.createDoc(bearerToken, function (err, doc) {
-                  if (err) return done(err);
-
-                  var client = request('http://' + config.get('server.host') + ':' + config.get('server.port'));
-
-                  client
-                  .get('/vtest/testdb/test-schema')
-                  .set('Authorization', 'Bearer ' + bearerToken)
-                  .expect(200)
-                  .end(function (err, res1) {
-                    if (err) return done(err);
-
-                    setTimeout(function() {
-
-                      // get the cache keys
-                      c.cache.cacheHandler.redisClient.KEYS('*', (err, keys) => {
-                        cacheKeys = keys
-
-                        client
-                        .post('/vtest/testdb/test-schema')
-                        .set('Authorization', 'Bearer ' + bearerToken)
-                        .send({field1: 'foo!'})
-                        .expect(200)
-                        .end(function (err, res2) {
-                          if (err) return done(err);
-
-                          setTimeout(function() {
-                            client
-                            .get('/vtest/testdb/test-schema')
-                            .set('Authorization', 'Bearer ' + bearerToken)
-                            .expect(200)
-                            .end(function (err, res3) {
-                              if (err) return done(err);
-
-                              cache.reset()
-                              res1.body.results.length.should.eql(2);
-                              res3.body.results.length.should.eql(3);
-                              res3.text.should.not.equal(res1.text);
-
-                              app.stop(function(){});
-                              done()
-                            });
-                          }, 500)
-                        });
-                      })
-                    }, 500)
-                  });
-                });
-              });
-            });
-          });
-        });
-      }
-      catch (err) {
-        console.log(err);
-        done();
-      }
-    });
-
-    it('should flush on PUT update request', function(done) {
-      this.timeout(8000)
-
-      delete require.cache[__dirname + '/../../config.js'];
-      delete require.cache[__dirname + '/../../dadi/lib/'];
-
-      config.loadFile(config.configPath());
+      config.loadFile(config.configPath())
 
       cache.reset()
       var c = cache(app)
@@ -1000,7 +883,7 @@ describe('Cache', function (done) {
         var stream = new Readable({objectMode: true})
 
         for (var i = 0; i < cacheKeys.length; i++) {
-          if (pattern.match === '*' || cacheKeys[i].indexOf(pattern.match.substring(0, pattern.match.length-1)) === 0) {
+          if (pattern.match === '*' || cacheKeys[i].indexOf(pattern.match.substring(0, pattern.match.length - 1)) === 0) {
             stream.push([cacheKeys[i]])
           } else {
             // console.log('rejected key: ', cacheKeys[i])
@@ -1012,29 +895,127 @@ describe('Cache', function (done) {
       }
 
       try {
-        app.start(function() {
+        app.start(function () {
           help.dropDatabase('test', function (err) {
-            if (err) return done(err);
+            if (err) return done(err)
 
             help.getBearerToken(function (err, token) {
-               if (err) return done(err);
-               bearerToken = token;
+              if (err) return done(err)
+              bearerToken = token
 
-               help.createDoc(bearerToken, function (err, doc) {
-                 if (err) return done(err);
+              help.createDoc(bearerToken, function (err, doc) {
+                if (err) return done(err)
 
-                 help.createDoc(bearerToken, function (err, doc) {
-                   if (err) return done(err);
+                help.createDoc(bearerToken, function (err, doc) {
+                  if (err) return done(err)
 
-                   var client = request('http://' + config.get('server.host') + ':' + config.get('server.port'));
+                  var client = request('http://' + config.get('server.host') + ':' + config.get('server.port'))
+
+                  client
+                  .get('/vtest/testdb/test-schema')
+                  .set('Authorization', 'Bearer ' + bearerToken)
+                  .expect(200)
+                  .end(function (err, res1) {
+                    if (err) return done(err)
+
+                    setTimeout(function () {
+                      // get the cache keys
+                      c.cache.cacheHandler.redisClient.KEYS('*', (err, keys) => {
+                        cacheKeys = keys
+
+                        client
+                        .post('/vtest/testdb/test-schema')
+                        .set('Authorization', 'Bearer ' + bearerToken)
+                        .send({field1: 'foo!'})
+                        .expect(200)
+                        .end(function (err, res2) {
+                          if (err) return done(err)
+
+                          setTimeout(function () {
+                            client
+                            .get('/vtest/testdb/test-schema')
+                            .set('Authorization', 'Bearer ' + bearerToken)
+                            .expect(200)
+                            .end(function (err, res3) {
+                              if (err) return done(err)
+
+                              cache.reset()
+                              res1.body.results.length.should.eql(2)
+                              res3.body.results.length.should.eql(3)
+                              res3.text.should.not.equal(res1.text)
+
+                              app.stop(function () {})
+                              done()
+                            })
+                          }, 500)
+                        })
+                      })
+                    }, 500)
+                  })
+                })
+              })
+            })
+          })
+        })
+      } catch (err) {
+        console.log(err)
+        done()
+      }
+    })
+
+    it('should flush on PUT update request', function (done) {
+      this.timeout(8000)
+
+      delete require.cache[__dirname + '/../../config.js']
+      delete require.cache[__dirname + '/../../dadi/lib/']
+
+      config.loadFile(config.configPath())
+
+      cache.reset()
+      var c = cache(app)
+      c.cache.cacheHandler.redisClient = fakeredis.createClient()
+      c.cache.cacheHandler.redisClient.status = 'ready'
+
+      c.cache.cacheHandler.redisClient.scanStream = function (pattern) {
+        var Readable = require('stream').Readable
+        var stream = new Readable({objectMode: true})
+
+        for (var i = 0; i < cacheKeys.length; i++) {
+          if (pattern.match === '*' || cacheKeys[i].indexOf(pattern.match.substring(0, pattern.match.length - 1)) === 0) {
+            stream.push([cacheKeys[i]])
+          } else {
+            // console.log('rejected key: ', cacheKeys[i])
+          }
+        }
+
+        stream.push(null)
+        return stream
+      }
+
+      try {
+        app.start(function () {
+          help.dropDatabase('test', function (err) {
+            if (err) return done(err)
+
+            help.getBearerToken(function (err, token) {
+              if (err) return done(err)
+              bearerToken = token
+
+              help.createDoc(bearerToken, function (err, doc) {
+                if (err) return done(err)
+
+                help.createDoc(bearerToken, function (err, doc) {
+                  if (err) return done(err)
+
+                  var client = request('http://' + config.get('server.host') + ':' + config.get('server.port'))
 
                    // GET
-                   client
+                  client
                    .get('/vtest/testdb/test-schema')
                    .set('Authorization', 'Bearer ' + bearerToken)
                    .expect(200)
                    .end(function (err, getRes1) {
-                     if (err) return done(err);
+                     if (err) return done(err)
 
                      // CREATE
                      client
@@ -1043,10 +1024,10 @@ describe('Cache', function (done) {
                      .send({field1: 'foo!'})
                      .expect(200)
                      .end(function (err, postRes1) {
-                       if (err) return done(err);
+                       if (err) return done(err)
 
                        // save id for updating
-                       var id = postRes1.body.results[0]._id;
+                       var id = postRes1.body.results[0]._id
 
                        // GET AGAIN - should cache new results
                        client
@@ -1054,9 +1035,9 @@ describe('Cache', function (done) {
                        .set('Authorization', 'Bearer ' + bearerToken)
                        .expect(200)
                        .end(function (err, getRes2) {
-                         if (err) return done(err);
+                         if (err) return done(err)
 
-                         setTimeout(function() {
+                         setTimeout(function () {
                            // get the cache keys
                            c.cache.cacheHandler.redisClient.KEYS('*', (err, keys) => {
                              cacheKeys = keys
@@ -1068,7 +1049,6 @@ describe('Cache', function (done) {
                              .send({field1: 'foo bar baz!'})
                              .expect(200)
                              .end(function (err, postRes2) {
-
                                // WAIT, then GET again
                                setTimeout(function () {
                                  client
@@ -1076,37 +1056,36 @@ describe('Cache', function (done) {
                                   .set('Authorization', 'Bearer ' + bearerToken)
                                   .expect(200)
                                   .end(function (err, getRes3) {
-                                    var result = _.findWhere(getRes3.body.results, { "_id": id });
-                                    result.field1.should.eql('foo bar baz!');
-                                    app.stop(function(){});
-                                    done();
-                                  });
-                               }, 500);
-                             });
-                          })
-                        }, 500)
-                       });
-                     });
-                   });
-                 });
-               });
-            });
-          });
-        });
+                                    var result = _.findWhere(getRes3.body.results, { '_id': id })
+                                    result.field1.should.eql('foo bar baz!')
+                                    app.stop(function () {})
+                                    done()
+                                  })
+                               }, 500)
+                             })
+                           })
+                         }, 500)
+                       })
+                     })
+                   })
+                })
+              })
+            })
+          })
+        })
+      } catch (err) {
+        console.log(err)
+        done()
       }
-      catch (err) {
-        console.log(err);
-        done();
-      }
-    });
+    })
 
-    it('should flush on DELETE request', function(done) {
+    it('should flush on DELETE request', function (done) {
       this.timeout(8000)
 
-      delete require.cache[__dirname + '/../../config.js'];
-      delete require.cache[__dirname + '/../../dadi/lib/'];
+      delete require.cache[__dirname + '/../../config.js']
+      delete require.cache[__dirname + '/../../dadi/lib/']
 
-      config.loadFile(config.configPath());
+      config.loadFile(config.configPath())
 
       cache.reset()
       var c = cache(app)
@@ -1118,7 +1097,7 @@ describe('Cache', function (done) {
         var stream = new Readable({objectMode: true})
 
         for (var i = 0; i < cacheKeys.length; i++) {
-          if (pattern.match === '*' || cacheKeys[i].indexOf(pattern.match.substring(0, pattern.match.length-1)) === 0) {
+          if (pattern.match === '*' || cacheKeys[i].indexOf(pattern.match.substring(0, pattern.match.length - 1)) === 0) {
             stream.push([cacheKeys[i]])
           } else {
             // console.log('rejected key: ', cacheKeys[i])
@@ -1130,29 +1109,29 @@ describe('Cache', function (done) {
       }
 
       try {
-        app.start(function() {
+        app.start(function () {
           help.dropDatabase('test', function (err) {
-            if (err) return done(err);
+            if (err) return done(err)
 
             help.getBearerToken(function (err, token) {
-               if (err) return done(err);
-               bearerToken = token;
+              if (err) return done(err)
+              bearerToken = token
+
+              help.createDoc(bearerToken, function (err, doc) {
+                if (err) return done(err)
 
                 help.createDoc(bearerToken, function (err, doc) {
-                  if (err) return done(err);
+                  if (err) return done(err)
 
-                  help.createDoc(bearerToken, function (err, doc) {
-                    if (err) return done(err);
-
-                    var client = request('http://' + config.get('server.host') + ':' + config.get('server.port'));
+                  var client = request('http://' + config.get('server.host') + ':' + config.get('server.port'))
 
                     // GET
-                    client
+                  client
                     .get('/vtest/testdb/test-schema')
                     .set('Authorization', 'Bearer ' + bearerToken)
                     .expect(200)
                     .end(function (err, getRes1) {
-                      if (err) return done(err);
+                      if (err) return done(err)
 
                       // CREATE
                       client
@@ -1161,10 +1140,10 @@ describe('Cache', function (done) {
                       .send({field1: 'foo!'})
                       .expect(200)
                       .end(function (err, postRes1) {
-                        if (err) return done(err);
+                        if (err) return done(err)
 
                         // save id for deleting
-                        var id = postRes1.body.results[0]._id;
+                        var id = postRes1.body.results[0]._id
 
                         // GET AGAIN - should cache new results
                         client
@@ -1172,7 +1151,6 @@ describe('Cache', function (done) {
                         .set('Authorization', 'Bearer ' + bearerToken)
                         .expect(200)
                         .end(function (err, getRes2) {
-
                           setTimeout(function () {
                             // get the cache keys
                             c.cache.cacheHandler.redisClient.KEYS('*', (err, keys) => {
@@ -1192,36 +1170,35 @@ describe('Cache', function (done) {
                                     .set('Authorization', 'Bearer ' + bearerToken)
                                     .expect(200)
                                     .end(function (err, getRes3) {
-                                      var result = _.findWhere(getRes3.body.results, { "_id": id });
-                                      should.not.exist(result);
-                                      app.stop(function(){});
-                                      done();
-                                    });
-                                  }, 300);
-                                });
-                              }, 700);
+                                      var result = _.findWhere(getRes3.body.results, { '_id': id })
+                                      should.not.exist(result)
+                                      app.stop(function () {})
+                                      done()
+                                    })
+                                  }, 300)
+                                })
+                              }, 700)
                             })
                           }, 500)
-                        });
-                      });
-                    });
-                  });
-                });
-            });
-          });
-        });
+                        })
+                      })
+                    })
+                })
+              })
+            })
+          })
+        })
+      } catch (err) {
+        console.log(err)
+        done()
       }
-      catch (err) {
-        console.log(err);
-        done();
-      }
-    });
+    })
 
-    it('should preserve content-type', function(done) {
-      delete require.cache[__dirname + '/../../config.js'];
-      delete require.cache[__dirname + '/../../dadi/lib/'];
+    it('should preserve content-type', function (done) {
+      delete require.cache[__dirname + '/../../config.js']
+      delete require.cache[__dirname + '/../../dadi/lib/']
 
-      config.loadFile(config.configPath());
+      config.loadFile(config.configPath())
 
       cache.reset()
       var c = cache(app)
@@ -1233,7 +1210,7 @@ describe('Cache', function (done) {
         var stream = new Readable({objectMode: true})
 
         for (var i = 0; i < cacheKeys.length; i++) {
-          if (pattern.match === '*' || cacheKeys[i].indexOf(pattern.match.substring(0, pattern.match.length-1)) === 0) {
+          if (pattern.match === '*' || cacheKeys[i].indexOf(pattern.match.substring(0, pattern.match.length - 1)) === 0) {
             stream.push([cacheKeys[i]])
           } else {
             // console.log('rejected key: ', cacheKeys[i])
@@ -1245,31 +1222,30 @@ describe('Cache', function (done) {
       }
 
       try {
-        app.start(function() {
+        app.start(function () {
+          var client = request('http://' + config.get('server.host') + ':' + config.get('server.port'))
 
-        var client = request('http://' + config.get('server.host') + ':' + config.get('server.port'));
-
-        client
+          client
         .get('/vtest/testdb/test-schema?callback=myCallback')
         .set('Authorization', 'Bearer ' + bearerToken)
         .expect(200)
         .expect('content-type', 'text/javascript')
         .end(function (err, res1) {
-          if (err) return done(err);
+          if (err) return done(err)
 
-          setTimeout(function() {
+          setTimeout(function () {
             // get the cache keys
             c.cache.cacheHandler.redisClient.KEYS('*', (err, keys) => {
               cacheKeys = keys
 
-              setTimeout(function() {
+              setTimeout(function () {
                 client
                 .post('/vtest/testdb/test-schema')
                 .set('Authorization', 'Bearer ' + bearerToken)
                 .send({field1: 'foo!'})
                 .expect(200)
                 .end(function (err, res) {
-                  if (err) return done(err);
+                  if (err) return done(err)
 
                   client
                   .get('/vtest/testdb/test-schema?callback=myCallback')
@@ -1277,22 +1253,21 @@ describe('Cache', function (done) {
                   .expect(200)
                   .expect('content-type', 'text/javascript')
                   .end(function (err, res2) {
-                    if (err) return done(err);
+                    if (err) return done(err)
 
-                    res2.text.should.not.equal(res1.text);
-                    app.stop(function(){});
-                    done();
-                  });
-                });
+                    res2.text.should.not.equal(res1.text)
+                    app.stop(function () {})
+                    done()
+                  })
+                })
               }, 500)
             })
           }, 500)
-        });
-      });
-    }
-    catch(err) {
+        })
+        })
+      } catch (err) {
 
-    }
-  });
-  });
-});
+      }
+    })
+  })
+})

--- a/test/acceptance/log.js
+++ b/test/acceptance/log.js
@@ -1,63 +1,63 @@
-var fs = require('fs');
-var should = require('should');
-var request = require('supertest');
+var fs = require('fs')
+var should = require('should')
+var request = require('supertest')
 
-var config = require(__dirname + '/../../config');
-var help = require(__dirname + '/help');
-var app = require(__dirname + '/../../dadi/lib/');
+var config = require(__dirname + '/../../config')
+var help = require(__dirname + '/help')
+var app = require(__dirname + '/../../dadi/lib/')
 
-var bearerToken;
-var connectionString = 'http://' + config.get('server.host') + ':' + config.get('server.port');
-var logpath = config.get('logging').path + '/' + config.get('logging').filename + '.access.' + config.get('logging').extension;
+var bearerToken
+var connectionString = 'http://' + config.get('server.host') + ':' + config.get('server.port')
+var logpath = config.get('logging').path + '/' + config.get('logging').filename + '.access.' + config.get('logging').extension
 
 var resetLog = function (done) {
     // empty the log for each test
-    fs.writeFileSync(logpath, new Buffer(''));
-    done();
-};
+  try {
+    fs.writeFileSync(logpath, new Buffer(''))
+  } catch (err) {
+    console.log(err.stack)
+  }
+  done()
+}
 
 describe('logger', function () {
-
   describe('request', function () {
-
-    beforeEach(resetLog);
+    beforeEach(resetLog)
 
     var cleanup = function (done) {
         // try to cleanup these tests directory tree
         // don't catch errors here, since the paths may not exist
 
-        var dirs = config.get('paths');
-        try {
-            fs.unlinkSync(dirs.collections + '/v1/testdb/collection.test-schema.json');
-        } catch (e) {}
+      var dirs = config.get('paths')
+      try {
+        fs.unlinkSync(dirs.collections + '/v1/testdb/collection.test-schema.json')
+      } catch (e) {}
 
-        try {
-            fs.rmdirSync(dirs.collections + '/v1/testdb');
-        } catch (e) {}
+      try {
+        fs.rmdirSync(dirs.collections + '/v1/testdb')
+      } catch (e) {}
 
-        done();
-    };
+      done()
+    }
 
     before(function (done) {
+      help.dropDatabase('testdb', function (err) {
+        if (err) return done(err)
 
-        help.dropDatabase('testdb', function (err) {
-            if (err) return done(err);
+        app.start(function () {
+          help.getBearerTokenWithAccessType('admin', function (err, token) {
+            if (err) return done(err)
 
-            app.start(function() {
-
-              help.getBearerTokenWithAccessType("admin", function (err, token) {
-                  if (err) return done(err);
-
-                  bearerToken = token;
+            bearerToken = token
 
                   // add a new field to the schema
-                  var jsSchemaString = fs.readFileSync(__dirname + '/../new-schema.json', {encoding: 'utf8'});
-                  jsSchemaString = jsSchemaString.replace('newField', 'field1');
-                  var schema = JSON.parse(jsSchemaString);
+            var jsSchemaString = fs.readFileSync(__dirname + '/../new-schema.json', {encoding: 'utf8'})
+            jsSchemaString = jsSchemaString.replace('newField', 'field1')
+            var schema = JSON.parse(jsSchemaString)
 
-                  var client = request(connectionString);
+            var client = request(connectionString)
 
-                  client
+            client
                   .post('/vtest/testdb/test-schema/config')
                   .send(JSON.stringify(schema, null, 4))
                   .set('content-type', 'text/plain')
@@ -65,24 +65,24 @@ describe('logger', function () {
                   .expect(200)
                   .expect('content-type', 'application/json')
                   .end(function (err, res) {
-                      if (err) return done(err);
+                    if (err) return done(err)
 
-                      done();
-                  });
-              });
-            });
-        });
-    });
+                    done()
+                  })
+          })
+        })
+      })
+    })
 
     after(function (done) {
         // reset the schema
-        var jsSchemaString = fs.readFileSync(__dirname + '/../new-schema.json', {encoding: 'utf8'});
-        jsSchemaString = jsSchemaString.replace('newField', 'field1');
-        var schema = JSON.parse(jsSchemaString);
+      var jsSchemaString = fs.readFileSync(__dirname + '/../new-schema.json', {encoding: 'utf8'})
+      jsSchemaString = jsSchemaString.replace('newField', 'field1')
+      var schema = JSON.parse(jsSchemaString)
 
-        var client = request(connectionString);
+      var client = request(connectionString)
 
-        client
+      client
         .post('/vtest/testdb/test-schema/config')
         .send(JSON.stringify(schema, null, 4))
         .set('content-type', 'text/plain')
@@ -90,19 +90,19 @@ describe('logger', function () {
         .expect(200)
         .expect('content-type', 'application/json')
         .end(function (err, res) {
-            if (err) return done(err);
+          if (err) return done(err)
 
-            cleanup(function() {
-              app.stop(done);
-            });
-        });
-    });
+          cleanup(function () {
+            app.stop(done)
+          })
+        })
+    })
 
     it('should log to the access log when collection endpoint is requested', function (done) {
       help.createDoc(bearerToken, function (err, doc) {
-        if (err) return done(err);
+        if (err) return done(err)
 
-        var client = request(connectionString);
+        var client = request(connectionString)
 
         client
         .get('/vtest/testdb/test-schema')
@@ -110,25 +110,25 @@ describe('logger', function () {
         .expect(200)
         .expect('content-type', 'application/json')
         .end(function (err, res) {
-          if (err) return done(err);
+          if (err) return done(err)
 
-          res.body['results'].should.exist;
-          res.body['results'].should.be.Array;
+          res.body['results'].should.exist
+          res.body['results'].should.be.Array
           res.body['results'].length.should.be.above(0)
 
-          var logEntry = fs.readFileSync(logpath, {encoding: 'utf8'});
-          logEntry.indexOf('/vtest/testdb/test-schema').should.be.above(0);
+          var logEntry = fs.readFileSync(logpath, {encoding: 'utf8'})
+          logEntry.indexOf('/vtest/testdb/test-schema').should.be.above(0)
 
-          done();
-        });
-      });
-    });
+          done()
+        })
+      })
+    })
 
     it('should determine the client IP address correctly', function (done) {
       help.createDoc(bearerToken, function (err, doc) {
-        if (err) return done(err);
+        if (err) return done(err)
 
-        var client = request(connectionString);
+        var client = request(connectionString)
 
         client
         .get('/vtest/testdb/test-schema')
@@ -137,14 +137,14 @@ describe('logger', function () {
         .expect(200)
         .expect('content-type', 'application/json')
         .end(function (err, res) {
-          if (err) return done(err);
+          if (err) return done(err)
 
-          var logEntry = fs.readFileSync(logpath, {encoding: 'utf8'});
-          logEntry.indexOf('52.101.34.175').should.be.above(0);
+          var logEntry = fs.readFileSync(logpath, {encoding: 'utf8'})
+          logEntry.indexOf('52.101.34.175').should.be.above(0)
 
-          done();
-        });
-      });
-    });
-  });
-});
+          done()
+        })
+      })
+    })
+  })
+})


### PR DESCRIPTION
This PR allows options to be passed to the instance of `@dadi/logger`, and works hand-in-hand with https://github.com/dadi/logger/pull/53.