### PR TITLE
Return current state of composition, not original

### DIFF
--- a/dadi/lib/model/composer.js
+++ b/dadi/lib/model/composer.js
@@ -102,7 +102,7 @@ Composer.prototype.compose = function (obj, callback) {
 
         // handles empty array
         if (originalValue.length === 0 && fieldNum === fields.length && docIdx === obj.length) {
-          return callback(obj)
+          return callback(composeCopy)
         } else {
           _.each(originalValue, (id) => {
             var results = _.filter(fieldData, r => { return id && r._id.toString() === id.toString() })

--- a/test/acceptance/fields/reference.js
+++ b/test/acceptance/fields/reference.js
@@ -776,7 +776,7 @@ describe('Reference Field', function () {
         var ernest = {
           name: 'Ernest Hemingway',
           friend: personId.toString(),
-          agent: personId.toString()
+          agent: []
         }
 
         client
@@ -789,7 +789,7 @@ describe('Reference Field', function () {
 
           ernest.name = 'Half Brother'
           ernest.spouse = ernest.friend
-          ernest.allFriends = [ernest.friend]
+          ernest.allFriends = []
 
           client
           .post('/v1/library/person')
@@ -798,8 +798,6 @@ describe('Reference Field', function () {
           .expect(200)
           .end(function (err, res) {
             if (err) return done(err)
-
-            // console.log(res)
 
             client
             .get('/v1/library/person?compose=true&filter={"name":"Half Brother"}')
@@ -811,8 +809,8 @@ describe('Reference Field', function () {
               should.exist(res.body.results)
               var result = res.body.results[0]
 
-              should.exist(result.allFriends)
-              result.allFriends[0].name.should.eql('Gertrude Stein')
+              should.exist(result.friend)
+              result.friend.name.should.eql('Gertrude Stein')
 
               done()
             })

--- a/test/acceptance/fields/reference.js
+++ b/test/acceptance/fields/reference.js
@@ -756,6 +756,71 @@ describe('Reference Field', function () {
       })
     })
 
+    it('should populate all reference fields when optional ones aren\'t defined', function (done) {
+      // first person
+      var gertrude = { name: 'Gertrude Stein' }
+
+      config.set('query.useVersionFilter', true)
+
+      var client = request(connectionString)
+      client
+      .post('/v1/library/person')
+      .set('Authorization', 'Bearer ' + bearerToken)
+      .send(gertrude)
+      .expect(200)
+      .end(function (err, res) {
+        if (err) return done(err)
+
+        var personId = res.body.results[0]._id
+
+        var ernest = {
+          name: 'Ernest Hemingway',
+          friend: personId.toString(),
+          agent: personId.toString()
+        }
+
+        client
+        .post('/v1/library/person')
+        .set('Authorization', 'Bearer ' + bearerToken)
+        .send(ernest)
+        .expect(200)
+        .end(function (err, res) {
+          if (err) return done(err)
+
+          ernest.name = 'Half Brother'
+          ernest.spouse = ernest.friend
+          ernest.allFriends = [ernest.friend]
+
+          client
+          .post('/v1/library/person')
+          .set('Authorization', 'Bearer ' + bearerToken)
+          .send(ernest)
+          .expect(200)
+          .end(function (err, res) {
+            if (err) return done(err)
+
+            // console.log(res)
+
+            client
+            .get('/v1/library/person?compose=true&filter={"name":"Half Brother"}')
+            .set('Authorization', 'Bearer ' + bearerToken)
+            .expect(200)
+            .end(function (err, res) {
+              if (err) return done(err)
+
+              should.exist(res.body.results)
+              var result = res.body.results[0]
+
+              should.exist(result.allFriends)
+              result.allFriends[0].name.should.eql('Gertrude Stein')
+
+              done()
+            })
+          })
+        })
+      })
+    })
+
     it('should return results for a reference field containing an Array of Strings', function (done) {
       var person = { name: 'Ernest Hemingway' }
       var book = { title: 'For Whom The Bell Tolls', author: null }

--- a/test/acceptance/workspace/collections/v1/library/collection.person.json
+++ b/test/acceptance/workspace/collections/v1/library/collection.person.json
@@ -21,7 +21,13 @@
   	},
     "friend": {
 	    "type": "Reference"
-  	}
+  	},
+    "agent": {
+      "type": "Reference"
+    },
+    "allFriends": {
+      "type": "Reference"
+    }
   },
 	"settings": {
     "cache": false,


### PR DESCRIPTION
### Does this resolve an issue?
Fix #390 

### Description of changes proposed in this pull request
rather than returning the original object passed to compose, return the new composed object in it’s current state

### Who should review this pull request?
@eduardoboucas 

### Testing
Test by performing a GET request for documents containing Reference fields, where each document has a different Reference field unpopulated.

