### PR TITLE
Handle Reference objects that are not arrays

### DIFF
--- a/dadi/lib/model/utils.js
+++ b/dadi/lib/model/utils.js
@@ -216,6 +216,8 @@ function stringifyProperties (obj) {
           // }
         } else if (value.match(/^[a-fA-F0-9]{24}$/) && validator.isMongoId(value)) {
           obj[key] = obj[key].toString()
+        } else if (typeof obj[key] === 'object') {
+          obj[key] = stringifyProperties(obj[key])
         }
         // else if (_.isEmpty(obj[key])) {
         //   delete obj[key]


### PR DESCRIPTION
When using a Reference field, it is possible to define as a single key rather than an array. When resolved, this remains an object, but is not properly sanitised.

This PR addresses this by handling nested objects.