### PR TITLE
Add handshake method to data connectors

### DIFF
--- a/dadi/lib/datastore/index.js
+++ b/dadi/lib/datastore/index.js
@@ -1,5 +1,8 @@
 const path = require('path')
 const config = require(path.join(__dirname, '/../../../config.js'))
+const semver = require('semver')
+
+let packageData = require('./../../../package.json')
 
 /**
  * Creates a new DataStore from the configuration property "datastore"
@@ -7,11 +10,34 @@ const config = require(path.join(__dirname, '/../../../config.js'))
  * @classdesc
  */
 const DataStore = function (storeName) {
-  const store = storeName || config.get('datastore')
+  let store = storeName || config.get('datastore')
+  let minimumVersion = packageData.dataConnectorDependencies[store]
 
   try {
-    const DataStore = require(store)
-    const instance = new DataStore()
+    let DataStore = require(store)
+    let instance = new DataStore()
+    let version = '0.0.0'
+
+    if (typeof instance.handshake === 'function') {
+      let connectorData = instance.handshake()
+
+      version = connectorData.version || version
+
+      if (
+        connectorData.minimumApiVersion &&
+        semver.lt(packageData.version, connectorData.minimumApiVersion)
+      ) {
+        throw new Error(
+          `The version of '${store}' being used (${version}) requires version ${connectorData.minimumApiVersion} (or greater) of DADI API. Please update your app or install an older version of the data connector, if available.`
+        )
+      }
+    }
+
+    if (minimumVersion && semver.lt(version, minimumVersion)) {
+      throw new Error(
+        `The minimum supported version of '${store}' is '${minimumVersion}'. Please update your dependency.`
+      )
+    }
 
     instance.settings = DataStore.settings || {}
 
@@ -28,3 +54,8 @@ const DataStore = function (storeName) {
 }
 
 module.exports = DataStore
+
+// Used for tests.
+module.exports.setPackageData = data => {
+  packageData = data
+}

--- a/package.json
+++ b/package.json
@@ -46,6 +46,7 @@
     "path-to-regexp": "~1.7.0",
     "recovery": "^0.2.6",
     "require-directory": "^2.1.1",
+    "semver": "^5.5.0",
     "serve-static": "^1.13.2",
     "sha1": "latest",
     "stack-trace": "latest",
@@ -69,6 +70,7 @@
     "lokijs": "^1.5.3",
     "mocha": "~4.0.1",
     "mochawesome": "^2.1.0",
+    "mock-require": "^3.0.2",
     "proxyquire": "^1.7.4",
     "should": "4.0.4",
     "sinon": "2.3.2",
@@ -76,6 +78,9 @@
     "standard": "8.6.0",
     "supertest": "~0.13.0",
     "uuid": "^3.2.1"
+  },
+  "dataConnectorDependencies": {
+    "@dadi/api-mongodb": "4.1.0"
   },
   "greenkeeper": {
     "ignore": [

--- a/test/unit/datastore.js
+++ b/test/unit/datastore.js
@@ -1,9 +1,298 @@
-var should = require('should')
-var DataStore = require(__dirname + '/../../dadi/lib/datastore')
+const app = require(__dirname + '/../../dadi/lib/')
+const config = require(__dirname + '/../../config')
+const DataStore = require(__dirname + '/../../dadi/lib/datastore')
+const mockRequire = require('mock-require')
+const path = require('path')
+const proxyquire = require('proxyquire')
+const should = require('should')
+const sinon = require('sinon')
 
 describe('DataStore', function () {
-  it('should throw an error when specifying an unknown connector', function (done) {
-    should.throws(function () { return DataStore('xxx') })
+  let datastoreBackup = config.get('datastore')
+
+  afterEach(() => {
+    config.set('datastore', datastoreBackup)
+  })
+
+  it('should throw an error when specifying an unknown connector', done => {
+    should.throws(() => DataStore('xxx'))
+
     done()
+  })
+
+  it('should call the constructor function of the data connector', done => {
+    let namespace = {
+      MockConnector: function () {}
+    }
+
+    namespace.MockConnector.prototype.connect = () => Promise.resolve()
+
+    let spy = sinon.spy(namespace, 'MockConnector')
+
+    mockRequire('@dadi/api-fakestore', namespace.MockConnector)
+
+    config.set('datastore', '@dadi/api-fakestore')
+
+    app.start(err => {
+      if (err) return done(err)
+
+      spy.called.should.eql(true)
+
+      setTimeout(() => {
+        app.stop(done)  
+      }, 250)
+    })
+  })
+
+  it('should call the handshake function of the data connector', done => {
+    let MockConnector = function () {}
+
+    MockConnector.prototype.connect = () => Promise.resolve()
+    MockConnector.prototype.handshake = sinon.stub().returns({
+      version: '1.0.0'
+    })
+
+    mockRequire('@dadi/api-fakestore', MockConnector)
+
+    config.set('datastore', '@dadi/api-fakestore')
+
+    app.start(err => {
+      if (err) return done(err)
+
+      MockConnector.prototype.handshake.called.should.eql(true)
+
+      setTimeout(() => {
+        app.stop(done)  
+      }, 250)
+    })
+  })
+
+  it('should not throw an error if the data connector does not implement a handshake function and there is no minimum version required set for it', done => {
+    let MockConnector = function () {}
+
+    MockConnector.prototype.connect = () => Promise.resolve()
+
+    mockRequire('@dadi/api-fakestore', MockConnector)
+
+    DataStore.setPackageData({
+      dataConnectorDependencies: {
+        '@dadi/api-someotherstore': '1.1.0'
+      }
+    })
+
+    config.set('datastore', '@dadi/api-fakestore')
+
+    app.start(err => {
+      if (err) return done(err)
+
+      setTimeout(() => {
+        app.stop(done)  
+      }, 250)
+    })
+  })
+
+  it('should throw an error if the data connector does not implement a handshake function and there is a minimum version required set for it', done => {
+    let MockConnector = function () {}
+
+    MockConnector.prototype.connect = () => Promise.resolve()
+
+    mockRequire('@dadi/api-fakestore', MockConnector)
+
+    DataStore.setPackageData({
+      dataConnectorDependencies: {
+        '@dadi/api-fakestore': '1.1.0'
+      }
+    })
+
+    config.set('datastore', '@dadi/api-fakestore')
+
+    try {
+      app.start()
+    } catch (err) {
+      err.should.be.Error
+      err.message.should.eql(
+        `The minimum supported version of '@dadi/api-fakestore' is '1.1.0'. Please update your dependency.`
+      )
+
+      setTimeout(() => {
+        app.stop(done)  
+      }, 250)
+    }
+  })
+
+  describe('data connector version check', () => {
+    it('should not throw an error if the version of the data connector is the same as the one required by API', done => {
+      let MockConnector = function () {}
+
+      MockConnector.prototype.connect = () => Promise.resolve()
+      MockConnector.prototype.handshake = () => ({
+        version: '1.1.0'
+      })
+
+      mockRequire('@dadi/api-fakestore', MockConnector)
+
+      DataStore.setPackageData({
+        dataConnectorDependencies: {
+          '@dadi/api-fakestore': '1.1.0'
+        }
+      })
+
+      config.set('datastore', '@dadi/api-fakestore')
+
+      app.start(err => {
+        if (err) return done(err)
+
+        setTimeout(() => {
+          app.stop(done)  
+        }, 250)
+      })
+    })
+
+    it('should not throw an error if the version of the data connector is greater than the one required by API', done => {
+      let MockConnector = function () {}
+
+      MockConnector.prototype.connect = () => Promise.resolve()
+      MockConnector.prototype.handshake = () => ({
+        version: '2.5.0'
+      })
+
+      mockRequire('@dadi/api-fakestore', MockConnector)
+
+      DataStore.setPackageData({
+        dataConnectorDependencies: {
+          '@dadi/api-fakestore': '1.1.0'
+        }
+      })
+
+      config.set('datastore', '@dadi/api-fakestore')
+
+      app.start(err => {
+        if (err) return done(err)
+
+        setTimeout(() => {
+          app.stop(done)  
+        }, 250)
+      })
+    })
+
+    it('should throw an error if the version of the data connector is lower than the one required by API', done => {
+      let MockConnector = function () {}
+
+      MockConnector.prototype.connect = () => Promise.resolve()
+      MockConnector.prototype.handshake = sinon.stub().returns({
+        version: '1.0.0'
+      })
+
+      mockRequire('@dadi/api-fakestore', MockConnector)
+
+      DataStore.setPackageData({
+        dataConnectorDependencies: {
+          '@dadi/api-fakestore': '1.1.0'
+        }
+      })
+
+      config.set('datastore', '@dadi/api-fakestore')
+
+      try {
+        app.start()
+      } catch (err) {
+        err.should.be.Error
+        err.message.should.eql(
+          `The minimum supported version of '@dadi/api-fakestore' is '1.1.0'. Please update your dependency.`
+        )
+
+        setTimeout(() => {
+          app.stop(done)  
+        }, 250)
+      }
+    })
+  })
+
+  describe('API version check', () => {
+    it('should not throw an error if the version of API is the same as the one required by the data connector', done => {
+      let MockConnector = function () {}
+
+      MockConnector.prototype.connect = () => Promise.resolve()
+      MockConnector.prototype.handshake = () => ({
+        minimumApiVersion: '3.2.0',
+        version: '1.1.0'
+      })
+
+      mockRequire('@dadi/api-fakestore', MockConnector)
+
+      DataStore.setPackageData({
+        dataConnectorDependencies: {},
+        version: '3.2.0'
+      })
+
+      config.set('datastore', '@dadi/api-fakestore')
+
+      app.start(err => {
+        if (err) return done(err)
+
+        setTimeout(() => {
+          app.stop(done)  
+        }, 250)
+      })
+    })
+
+    it('should not throw an error if the version of API is greater than the one required by the data connector', done => {
+      let MockConnector = function () {}
+
+      MockConnector.prototype.connect = () => Promise.resolve()
+      MockConnector.prototype.handshake = () => ({
+        minimumApiVersion: '3.0.0',
+        version: '2.5.0'
+      })
+
+      mockRequire('@dadi/api-fakestore', MockConnector)
+
+      DataStore.setPackageData({
+        dataConnectorDependencies: {},
+        version: '3.2.0'
+      })
+
+      config.set('datastore', '@dadi/api-fakestore')
+
+      app.start(err => {
+        if (err) return done(err)
+
+        setTimeout(() => {
+          app.stop(done)  
+        }, 250)
+      })
+    })
+
+    it('should throw an error if the version of API is lower than the one required by the data connector', done => {
+      let MockConnector = function () {}
+
+      MockConnector.prototype.connect = () => Promise.resolve()
+      MockConnector.prototype.handshake = sinon.stub().returns({
+        minimumApiVersion: '3.1.0',
+        version: '1.0.0'
+      })
+
+      mockRequire('@dadi/api-fakestore', MockConnector)
+
+      DataStore.setPackageData({
+        dataConnectorDependencies: {},
+        version: '3.0.0'
+      })
+
+      config.set('datastore', '@dadi/api-fakestore')
+
+      try {
+        app.start()
+      } catch (err) {
+        err.should.be.Error
+        err.message.should.eql(
+          `The version of '@dadi/api-fakestore' being used (1.0.0) requires version 3.1.0 (or greater) of DADI API. Please update your app or install an older version of the data connector, if available.`
+        )
+
+        setTimeout(() => {
+          app.stop(done)  
+        }, 250)
+      }
+    })
   })
 })


### PR DESCRIPTION
This PR adds a check for a function named `handshake` in the data connector modules. If present, it will be called to obtain an object with information from the data connector, more precisely an object with the following properties:

- `minimumApiVersion`: The minimum version of API required by the data connector
- `version`: The version of the data connector module

Given these two values, an error is thrown in one of two situations:

- The current version of API is lower than the one specified by the data connector
- The current version of API requires a version of that particular data connector that is greater than the one being used

For the latter to work, API stores in `package.json` a list of minimum version requirements for the various data connectors, as following:

```json
"dataConnectorDependencies": {
  "@dadi/api-mongodb": "4.1.0"
}
```