### PR TITLE
Make default paths relative to parent app

### DIFF
--- a/config.js
+++ b/config.js
@@ -232,17 +232,17 @@ var conf = convict({
     collections: {
       doc: 'The relative or absolute path to collection specification files',
       format: String,
-      default: __dirname + '/workspace/collections'
+      default: 'workspace/collections'
     },
     endpoints: {
       doc: 'The relative or absolute path to custom endpoint files',
       format: String,
-      default: __dirname + '/workspace/endpoints'
+      default: 'workspace/endpoints'
     },
     hooks: {
       doc: 'The relative or absolute path to hook specification files',
       format: String,
-      default: __dirname + '/workspace/hooks'
+      default: 'workspace/hooks'
     }
   },
   feedback: {


### PR DESCRIPTION
This PR makes the default paths for collections, custom endpoints and hooks relative to the parent app instead of the `@dadi/api` module. In practice, this means that users don't need to actively specify the paths to their `workspace` directories as currently happens. Those will be assumed by default. When working from the cloned repository, everything still works the same.

Closes #371.
Closes #384.