### PR TITLE
Fix logging initialised twice

### DIFF
--- a/dadi/lib/index.js
+++ b/dadi/lib/index.js
@@ -162,8 +162,6 @@ Server.prototype.start = function (done) {
   var self = this
   this.readyState = 2
 
-  this.initialiseLog()
-
   var defaultPaths = {
     collections: path.join(__dirname, '/../../workspace/collections'),
     endpoints: path.join(__dirname, '/../../workspace/endpoints')


### PR DESCRIPTION
The second initialise clears the logging configuration

Fix #409