### PR TITLE
Media document format

### DIFF
--- a/dadi/lib/model/media.js
+++ b/dadi/lib/model/media.js
@@ -68,7 +68,7 @@ MediaModel.prototype.formatDocuments = function (documents) {
 
     // Is this a relative path to a file in the disk? If so, we need to prepend
     // the API URL.
-    if (formattedDocument.path.indexOf('/') === 0) {
+    if (formattedDocument.path && formattedDocument.path.indexOf('/') === 0) {
       formattedDocument.url = this.getURLForPath(formattedDocument.path)
     }
 


### PR DESCRIPTION
This PR allows for limiting fields returned in a media collection GET request. An error occurred if the `path` property wasn't included in the list of fields to return, as the `url` property is derived from this.  The change involves guarding against the `path` property not being included in the to-be-formatted documents.

Fix #425 

