### PR TITLE
Stringify ACL fields and filters before saving

### DIFF
--- a/dadi/lib/model/acl/access.js
+++ b/dadi/lib/model/acl/access.js
@@ -154,7 +154,9 @@ Access.prototype.get = function ({clientId = null, accessType = null} = {}, reso
   }).then(({results}) => {
     if (!resource) {
       let accessByResource = results.reduce((output, result) => {
-        output[result.resource] = result.access
+        output[result.resource] = resolveOwnTypes
+          ? this.resolveOwnTypes(result.access, clientId)
+          : result.access
 
         return output
       }, {})

--- a/dadi/lib/model/acl/client.js
+++ b/dadi/lib/model/acl/client.js
@@ -178,7 +178,9 @@ Client.prototype.resourceAdd = function (clientId, resource, access) {
       },
       rawOutput: true,
       update: {
-        resources: resources.getAll()
+        resources: resources.getAll({
+          formatForInput: true
+        })
       },
       validate: false
     })
@@ -290,7 +292,9 @@ Client.prototype.resourceUpdate = function (clientId, resource, access) {
       },
       rawOutput: true,
       update: {
-        resources: resources.getAll()
+        resources: resources.getAll({
+          formatForInput: true
+        })
       },
       validate: false
     })
@@ -443,7 +447,9 @@ Client.prototype.sanitise = function (client) {
       if (key === 'resources') {
         let resources = new ACLMatrix(value)
 
-        value = resources.format()
+        value = resources.getAll({
+          formatForOutput: true
+        })
       }
 
       output[key] = value

--- a/dadi/lib/model/acl/role.js
+++ b/dadi/lib/model/acl/role.js
@@ -162,7 +162,9 @@ Role.prototype.resourceAdd = function (role, resource, access) {
       },
       rawOutput: true,
       update: {
-        resources: resources.getAll()
+        resources: resources.getAll({
+          formatForInput: true
+        })
       },
       validate: false
     })
@@ -273,7 +275,9 @@ Role.prototype.resourceUpdate = function (role, resource, access) {
       },
       rawOutput: true,
       update: {
-        resources: resources.getAll()
+        resources: resources.getAll({
+          formatForInput: true
+        })
       },
       validate: false
     })
@@ -300,7 +304,9 @@ Role.prototype.sanitise = function (role) {
       if (key === 'resources') {
         let resources = new ACLMatrix(output[key])
 
-        output[key] = resources.format()
+        output[key] = resources.getAll({
+          formatForOutput: true
+        })
       }
     }
 


### PR DESCRIPTION
With this PR, ACL fields and filters will be stringified before being saved to the database and then parsed on the way out. This fixes an issue where certain database engines, such as MongoDB, don't like keys starting with special characters (like `$`).

@jimlambie if you're happy with it, could you please merge and let @davidmacp know that it's ready for him to retest? You can either release this as RC3 or ask him to test from `develop`.