### PR TITLE
Add additional content-type to the allowed list

### DIFF
--- a/dadi/lib/index.js
+++ b/dadi/lib/index.js
@@ -203,7 +203,8 @@ Server.prototype.start = function (done) {
 
   app.use(bodyParser.json({ limit: '50mb',
     type: req => {
-      if (['text/plain', 'text/plain; charset=utf-8', 'application/json'].includes(req.headers['content-type'])) {
+      let contentType = req.headers['content-type'] || ''
+      if (['text/plain', 'text/plain; charset=utf-8', 'application/json', 'application/json; charset=utf-8'].includes(contentType.toLowerCase())) {
         let parts = req.url.split('/').filter(Boolean)
 
         // don't allow parsing into JSON if:

--- a/test/acceptance/rest-endpoints/collections-api/post.js
+++ b/test/acceptance/rest-endpoints/collections-api/post.js
@@ -182,6 +182,33 @@ describe('Collections API – POST', function () {
       })
   })
 
+  it('should create new documents when content-type includes a charset', function (done) {
+    var body = JSON.stringify({
+      field1: 'foo!'
+    })
+
+    var client = request(connectionString)
+
+    client
+      .post('/vtest/testdb/test-schema')
+      .set('Authorization', 'Bearer ' + bearerToken)
+      .set('content-type', 'application/json; charset=UTF-8')
+      .send(body)
+      .expect(200)
+      .end(function (err, res) {
+        if (err) return done(err)
+
+        should.exist(res.body.results)
+
+        res.body.results.should.be.Array
+        res.body.results.length.should.equal(1)
+        should.exist(res.body.results[0]._id)
+        should.exist(res.body.results[0].field1)
+        res.body.results[0].field1.should.equal('foo!')
+        done()
+      })
+  })
+
   it('should create new documents with ObjectIDs from single value', function (done) {
     var body = { field1: 'foo!', field2: 1278, field3: '55cb1658341a0a804d4dadcc' }
     var client = request(connectionString)


### PR DESCRIPTION
This PR simply adds an additional content type check when determining if the current request should be parsed by the JSON parsing middleware.

Fix #445 

