### PR TITLE
Throw error when before hooks are missing a return statement

### DIFF
--- a/dadi/lib/model/hook.js
+++ b/dadi/lib/model/hook.js
@@ -29,7 +29,7 @@ const Hook = function (data, type) {
     this.options = data.options
   }
 
-  this.hook = function (arg, type) {
+  this.hook = function (obj, type) {
     let result
 
     try {

--- a/dadi/lib/model/hook.js
+++ b/dadi/lib/model/hook.js
@@ -29,7 +29,7 @@ const Hook = function (data, type) {
     this.options = data.options
   }
 
-  this.hook = function () {
+  this.hook = function (arg, type) {
     let result
 
     try {
@@ -38,6 +38,12 @@ const Hook = function (data, type) {
       result = hookFn.apply(this, arguments)
     } catch (error) {
       result = Promise.reject(error)
+    }
+
+    if (result === undefined && type.indexOf('before') === 0) {
+      return Promise.reject(
+        `Missing return statement on ${type} hook`
+      )
     }
 
     return result

--- a/test/unit/model/hooks.js
+++ b/test/unit/model/hooks.js
@@ -318,6 +318,8 @@ describe('Hook', function () {
       var inspectFunction = function (obj, type, data) {
         JSON.stringify(data.schema).should.eql(JSON.stringify(schema))
         data.collection.should.eql('testModelName')
+
+        return obj
       }
 
       sinon.stub(hook.Hook.prototype, 'load').returns(inspectFunction)
@@ -544,6 +546,8 @@ describe('Hook', function () {
       var inspectFunction = function (obj, type, data) {
         JSON.stringify(data.schema).should.eql(JSON.stringify(schema))
         data.collection.should.eql('testModelName')
+
+        return obj
       }
 
       sinon.stub(hook.Hook.prototype, 'load').returns(inspectFunction)
@@ -714,6 +718,8 @@ describe('Hook', function () {
       var inspectFunction = function (obj, type, data) {
         JSON.stringify(data.schema).should.eql(JSON.stringify(schema))
         data.collection.should.eql('testModelName')
+
+        return obj
       }
 
       sinon.stub(hook.Hook.prototype, 'load').returns(inspectFunction)
@@ -820,6 +826,8 @@ describe('Hook', function () {
       var inspectFunction = function (obj, type, data) {
         JSON.stringify(data.schema).should.eql(JSON.stringify(schema))
         data.collection.should.eql('testModelName')
+
+        return obj
       }
 
       sinon.stub(hook.Hook.prototype, 'load').returns(inspectFunction)
@@ -932,6 +940,8 @@ describe('Hook', function () {
       var inspectFunction = function (obj, type, data) {
         JSON.stringify(data.schema).should.eql(JSON.stringify(schema))
         data.collection.should.eql('testModelName')
+
+        return obj
       }
 
       sinon.stub(hook.Hook.prototype, 'load').returns(inspectFunction)
@@ -990,6 +1000,8 @@ describe('Hook', function () {
         data.deletedDocs.should.be.Array
         data.deletedDocs.length.should.eql(1)
         data.deletedDocs[0].fieldName.should.eql('foo')
+
+        return obj
       }
 
       sinon.stub(hook.Hook.prototype, 'load').returns(inspectFunction)
@@ -1111,6 +1123,8 @@ describe('Hook', function () {
       var inspectFunction = function (obj, type, data) {
         JSON.stringify(data.schema).should.eql(JSON.stringify(schema))
         data.collection.should.eql('testModelName')
+
+        return obj
       }
 
       sinon.stub(hook.Hook.prototype, 'load').returns(inspectFunction)
@@ -1162,6 +1176,8 @@ describe('Hook', function () {
         data.deletedDocs.should.be.Array
         data.deletedDocs.length.should.eql(1)
         data.deletedDocs[0].fieldName.should.eql('foo')
+
+        return obj
       }
 
       sinon.stub(hook.Hook.prototype, 'load').returns(inspectFunction)
@@ -1283,6 +1299,8 @@ describe('Hook', function () {
       var inspectFunction = function (obj, type, data) {
         JSON.stringify(data.schema).should.eql(JSON.stringify(schema))
         data.collection.should.eql('testModelName')
+
+        return obj
       }
 
       sinon.stub(hook.Hook.prototype, 'load').returns(inspectFunction)
@@ -1381,6 +1399,8 @@ describe('Hook', function () {
       var inspectFunction = function (obj, type, data) {
         JSON.stringify(data.schema).should.eql(JSON.stringify(schema))
         data.collection.should.eql('testModelName')
+
+        return obj
       }
 
       sinon.stub(hook.Hook.prototype, 'load').returns(inspectFunction)


### PR DESCRIPTION
`before*` hooks are expected to return a value, which will be used by API in the corresponding CRUD operation. When this doesn't happen, API is currently responding with a less than ideal error message. This PR adds an explicit check for that scenario, returning an error message like the one below:

```json
    {
        "code": "API-0002",
        "title": "Hook Error",
        "details": "hook1 - Missing return statement on beforeCreate hook",
        "hookName": "hook1",
        "docLink": "https://docs.dadi.cloud/api/#api-0002"
    }
```

/cc @danwdart 

Closes #452.