### PR TITLE
Change ACL serialisation method

### DIFF
--- a/dadi/lib/model/acl/client.js
+++ b/dadi/lib/model/acl/client.js
@@ -148,9 +148,19 @@ Client.prototype.get = function (clientId, secret) {
 
   return this.model.find({
     query
-  }).then(response => ({
-    results: response.results
-  }))
+  }).then(response => {
+    let formattedResults = response.results.map(result => {
+      let resources = new ACLMatrix(result.resources)
+
+      return Object.assign({}, result, {
+        resources: resources.getAll()
+      })
+    })
+
+    return {
+      results: formattedResults
+    }
+  })
 }
 
 /**
@@ -209,6 +219,7 @@ Client.prototype.resourceAdd = function (clientId, resource, access) {
       rawOutput: true,
       update: {
         resources: resources.getAll({
+          getArrayNotation: true,
           stringifyObjects: true
         })
       },
@@ -323,6 +334,7 @@ Client.prototype.resourceUpdate = function (clientId, resource, access) {
       rawOutput: true,
       update: {
         resources: resources.getAll({
+          getArrayNotation: true,
           stringifyObjects: true
         })
       },

--- a/dadi/lib/model/acl/role.js
+++ b/dadi/lib/model/acl/role.js
@@ -140,9 +140,19 @@ Role.prototype.get = function (names) {
 
   return this.model.find({
     query
-  }).then(response => ({
-    results: response.results
-  }))
+  }).then(response => {
+    let formattedResults = response.results.map(result => {
+      let resources = new ACLMatrix(result.resources)
+
+      return Object.assign({}, result, {
+        resources: resources.getAll()
+      })
+    })
+
+    return {
+      results: formattedResults
+    }
+  })
 }
 
 /**
@@ -190,6 +200,7 @@ Role.prototype.resourceAdd = function (role, resource, access) {
       rawOutput: true,
       update: {
         resources: resources.getAll({
+          getArrayNotation: true,
           stringifyObjects: true
         })
       },
@@ -304,6 +315,7 @@ Role.prototype.resourceUpdate = function (role, resource, access) {
       rawOutput: true,
       update: {
         resources: resources.getAll({
+          getArrayNotation: true,
           stringifyObjects: true
         })
       },

--- a/test/acceptance/acl/clients-api/roles-delete.js
+++ b/test/acceptance/acl/clients-api/roles-delete.js
@@ -208,12 +208,13 @@ module.exports = () => {
   })
 
   describe('success states (the client has "update" access to the "clients" resource and has all the roles they are trying to assign)', () => {
-    it('should remove a role from a client', () => {
+    it('should remove a role from a client', done => {
       let testClient = {
         clientId: 'apiClient',
         secret: 'someSecret',
         resources: {
           clients: {
+            read: true,
             update: true
           }
         },

--- a/test/acceptance/help.js
+++ b/test/acceptance/help.js
@@ -163,6 +163,19 @@ module.exports.createACLClient = function (client, callback) {
     config.get('datastore')
   )
 
+  let resources = client.resources
+
+  if (resources && !Array.isArray(resources)) {
+    resources = Object.keys(resources).map(resource => {
+      return {
+        r: resource,
+        a: resources[resource]
+      }
+    })
+
+    client.resources = resources
+  }
+
   return clientsConnection.datastore.insert({
     data: client,
     collection: config.get('auth.clientCollection'),
@@ -194,6 +207,19 @@ module.exports.createACLRole = function (role, callback) {
     null,
     config.get('datastore')
   )
+
+  let resources = role.resources
+
+  if (resources && !Array.isArray(resources)) {
+    resources = Object.keys(resources).map(resource => {
+      return {
+        r: resource,
+        a: resources[resource]
+      }
+    })
+
+    role.resources = resources
+  }  
 
   return rolesConnection.datastore.insert({
     data: role,

--- a/test/acceptance/help.js
+++ b/test/acceptance/help.js
@@ -163,19 +163,6 @@ module.exports.createACLClient = function (client, callback) {
     config.get('datastore')
   )
 
-  let resources = client.resources
-
-  if (resources && !Array.isArray(resources)) {
-    resources = Object.keys(resources).map(resource => {
-      return {
-        r: resource,
-        a: resources[resource]
-      }
-    })
-
-    client.resources = resources
-  }
-
   return clientsConnection.datastore.insert({
     data: client,
     collection: config.get('auth.clientCollection'),
@@ -207,19 +194,6 @@ module.exports.createACLRole = function (role, callback) {
     null,
     config.get('datastore')
   )
-
-  let resources = role.resources
-
-  if (resources && !Array.isArray(resources)) {
-    resources = Object.keys(resources).map(resource => {
-      return {
-        r: resource,
-        a: resources[resource]
-      }
-    })
-
-    role.resources = resources
-  }  
 
   return rolesConnection.datastore.insert({
     data: role,

--- a/test/test-connector/index.js
+++ b/test/test-connector/index.js
@@ -14,7 +14,7 @@ const util = require('util')
 const Update = require('./lib/update')
 const uuid = require('uuid')
 
-const DEBUG = false
+const DEBUG = Boolean(process.env.DEBUG_DB)
 const STATE_DISCONNECTED = 0
 const STATE_CONNECTED = 1
 

--- a/test/unit/acl/matrix.js
+++ b/test/unit/acl/matrix.js
@@ -519,4 +519,114 @@ describe('ACL access matrix', function () {
       }
     })
   })
+
+  describe('array and object notations', () => {
+    it('should leave the map untouched when trying to convert from array notation to object notation a map that is not an array', () => {
+      let matrix = new Matrix()
+      let input = {
+        'resource:one': {
+          create: true,
+          read: true,
+          update: true
+        },
+        'resource:two': {
+          delete: true,
+          update: true
+        }
+      }
+
+      matrix._convertArrayNotationToObjectNotation(input).should.eql(input)
+    })
+
+    it('should convert an empty map from array notation to object notation', () => {
+      let matrix = new Matrix()
+      let input = []
+
+      matrix._convertArrayNotationToObjectNotation(input).should.eql({})
+    })
+
+    it('should convert a map from array notation to object notation', () => {
+      let matrix = new Matrix()
+      let input = [
+        {
+          r: 'resource:one',
+          a: {
+            create: true,
+            read: true,
+            update: true
+          }
+        },
+        {
+          r: 'resource:two',
+          a: {
+            delete: true,
+            update: true
+          }
+        }
+      ]
+
+      matrix._convertArrayNotationToObjectNotation(input).should.eql({
+        [input[0].r]: input[0].a,
+        [input[1].r]: input[1].a
+      })
+    })
+
+    it('should leave the map untouched when trying to convert from object notation to array notation a map that is already an array', () => {
+      let matrix = new Matrix()
+      let input = [
+        {
+          r: 'resource:one',
+          a: {
+            create: true,
+            read: true,
+            update: true
+          }
+        },
+        {
+          r: 'resource:two',
+          a: {
+            delete: true,
+            update: true
+          }
+        }
+      ]
+
+      matrix._convertObjectNotationToArrayNotation(input).should.eql(input)
+    })    
+
+    it('should convert an empty map from object notation to array notation', () => {
+      let matrix = new Matrix()
+      let input = {}
+
+      matrix._convertArrayNotationToObjectNotation(input).should.eql([])
+    })
+
+    it('should convert a map from object notation to array notation', () => {
+      let matrix = new Matrix()
+      let input = {
+        'resource:one': {
+          create: true,
+          read: true,
+          update: true
+        },
+        'resource:two': {
+          delete: true,
+          update: true
+        }
+      }
+
+      matrix._convertObjectNotationToArrayNotation(input).should.eql(
+        [
+          {
+            r: 'resource:one',
+            a: input['resource:one']
+          },
+          {
+            r: 'resource:two',
+            a: input['resource:two']
+          }
+        ]
+      )
+    })    
+  })
 })


### PR DESCRIPTION
Previously, ACL data for a list of resources would be stored as:

```js
{
  'resource:1.0_one': {
    create: true,
    read: true,
    update: true
  },
  'resource:1.0_two': {
    delete: true,
    update: true
  }
}
```

This is a problem when using a MongoDB database, since `resource:1.0_one` is not a valid key (because of the dot). As a result, this PR changes the above structure to:

```js
[
  {
    r: 'resource:one',
    a: {
      create: true,
      read: true,
      update: true
    }
  },
  {
    r: 'resource:two',
    a: {
      delete: true,
      update: true
    }
  }
]
```

This is then translated back to the object notation for output and for a series of internal manipulations. The user will never see the array notation.