### PR TITLE
Allow multiple file uploads

### DIFF
--- a/dadi/lib/index.js
+++ b/dadi/lib/index.js
@@ -1146,7 +1146,7 @@ Server.prototype.addComponent = function (options) {
           }
 
           if (options.component.setPayload) {
-            options.component.setPayload(payload)
+            options.component.setPayload(req.params.token, payload)
           }
 
           return options.component[method](req, res, next)

--- a/package.json
+++ b/package.json
@@ -4,9 +4,9 @@
   "main": "main.js",
   "scripts": {
     "create-client": "cd ../../.. && node ./node_modules/@dadi/api/utils/create-client.js",
-    "docs": "jsdoc -c ./docs/conf.json -R README.md -r dadi/lib -d docs",
     "commitmsg": "commitlint -e",
-    "test": "standard 'dadi/**/*.js' | snazzy && env NODE_ENV=test ./node_modules/.bin/istanbul cover  --report cobertura --report text --report html --report lcov ./node_modules/mocha/bin/_mocha",
+    "test:prepare": "rm -rf cache && rm -rf config/config.test.json && rm -rf test/acceptance/temp-workspace && cp -R test/acceptance/workspace test/acceptance/temp-workspace",
+    "test": "npm run test:prepare && standard 'dadi/**/*.js' | snazzy && env NODE_ENV=test ./node_modules/.bin/istanbul cover  --report cobertura --report text --report html --report lcov ./node_modules/mocha/bin/_mocha",
     "posttest": "./scripts/coverage.js",
     "start": "node start.js --node_env=development"
   },

--- a/test/acceptance/rest-endpoints/collections-api/put.js
+++ b/test/acceptance/rest-endpoints/collections-api/put.js
@@ -179,7 +179,7 @@ describe('Collections API – PUT', function () {
       .set('Authorization', 'Bearer ' + bearerToken)
       .send({
         query: {
-          _id: '59f1b3e038ad765e669ac47f',
+          _id: '59f1b3e038ad765e669ac47f'
         },
         update: {
           field1: 'updated doc'
@@ -604,7 +604,7 @@ describe('Collections API – PUT', function () {
                       .post('/vjoin/testdb/test-schema-no-history')
                       .set('Authorization', 'Bearer ' + token)
                       .send({field1: 'doc'})
-                      // .expect(200)
+                      .expect(200)
                       .end(function (err, res) {
                         if (err) return done(err)
 


### PR DESCRIPTION
This PR modifies the media controller to use function scoped variables. Prior to this multiple requests to the media controller in quick succession had the effect of concatenating buffer chunks from multiple files into a single writeStream - which results in nonsense.

Fix #466  (this is the backport of the fix in 4.0.3)