### PR TITLE
Use API error codes on invalid/missing client secret

### DIFF
--- a/dadi/lib/controller/clients.js
+++ b/dadi/lib/controller/clients.js
@@ -234,10 +234,7 @@ Clients.prototype.handleError = function (res, next) {
         })
 
       case 'INVALID_SECRET':
-        return help.sendBackJSON(400, res, next)(null, {
-          success: false,
-          errors: ['The supplied current secret is not valid']
-        })
+        return help.sendBackErrorWithCode('0008', 400, res, next)
 
       case 'MISSING_FIELDS':
         return help.sendBackJSON(400, res, next)(null, {
@@ -246,10 +243,7 @@ Clients.prototype.handleError = function (res, next) {
         })
 
       case 'MISSING_SECRET':
-        return help.sendBackJSON(400, res, next)(null, {
-          success: false,
-          errors: ['The current secret must be supplied via a `currentSecret` property']
-        })
+        return help.sendBackErrorWithCode('0007', 400, res, next)
 
       case 'PROTECTED_DATA_FIELDS':
         return help.sendBackJSON(400, res, next)(null, {

--- a/dadi/lib/help.js
+++ b/dadi/lib/help.js
@@ -36,6 +36,18 @@ module.exports.sendBackErrorTrace = function (res, next) {
   }
 }
 
+module.exports.sendBackErrorWithCode = function (errorCode, statusCode, res, next) {
+  if (typeof statusCode !== 'number') {
+    next = res
+    res = statusCode
+    statusCode = 500
+  }
+
+  let errorObject = formatError.createError('api', errorCode, null, ERROR_CODES)
+
+  return module.exports.sendBackJSON(statusCode, res, next)(null, errorObject)
+}
+
 // helper that sends json response
 module.exports.sendBackJSON = function (successCode, res, next) {
   return function (err, results) {

--- a/error-codes.json
+++ b/error-codes.json
@@ -34,5 +34,17 @@
     "title": "Access denied",
     "details": "The bearer token supplied in the request does not have sufficient permissions to perform the operation.",
     "params": []
-  }  
+  },
+  "0007": {
+    "code": "API-0007",
+    "title": "Current secret missing",
+    "details": "To update the client secret, the current secret must be supplied via the `currentSecret` property.",
+    "params": []
+  },
+  "0008": {
+    "code": "API-0008",
+    "title": "Current secret not valid",
+    "details": "The supplied current secret is not valid.",
+    "params": []
+  }
 }

--- a/test/acceptance/acl/clients-api/put.js
+++ b/test/acceptance/acl/clients-api/put.js
@@ -461,8 +461,8 @@ module.exports = () => {
           .end((err, res) => {
             res.statusCode.should.eql(400)
 
-            res.body.success.should.eql(false)
-            res.body.errors[0].should.eql('The current secret must be supplied via a `currentSecret` property')
+            res.body.code.should.eql('API-0007')
+            res.body.title.should.be.String
 
             client
             .post(config.get('auth.tokenUrl'))
@@ -520,8 +520,8 @@ module.exports = () => {
           .end((err, res) => {
             res.statusCode.should.eql(400)
 
-            res.body.success.should.eql(false)
-            res.body.errors[0].should.eql('The current secret supplied is not valid')
+            res.body.code.should.eql('API-0008')
+            res.body.title.should.be.String
 
             client
             .post(config.get('auth.tokenUrl'))


### PR DESCRIPTION
This PR also adds a `sendBackErrorWithCode` helper method, which receives an API error code and a status code (defaulting to `500`) and outputs the corresponding JSON response.