### PR TITLE
Add branch name check to precommit hooks

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "test:prepare": "rm -rf cache && rm -rf config/config.test.json && rm -rf test/acceptance/temp-workspace && cp -R test/acceptance/workspace test/acceptance/temp-workspace",
     "test": "npm run test:prepare && standard --fix 'dadi/**/*.js' | snazzy && env NODE_ENV=test ./node_modules/.bin/istanbul cover  --report cobertura --report text --report html --report lcov ./node_modules/mocha/bin/_mocha && npm run test:cleanup",
     "test:cleanup": "rm -rf test/acceptance/temp-workspace",
+    "precommit": "node scripts/precommit.js",
     "posttest": "./scripts/coverage.js",
     "start": "node start.js --node_env=development"
   },

--- a/scripts/precommit.js
+++ b/scripts/precommit.js
@@ -1,0 +1,42 @@
+#!/usr/bin/env node
+
+const exec = require('child_process').exec
+
+function currentBranch () {
+  return new Promise((resolve, reject) => {
+    exec('git branch --no-color', (err, out) => {
+      if (err) return reject(err)
+
+      let branches = out.split('\n')
+      let branch = branches.find(branch => {
+        return /^\*/.test(branch)
+      })
+
+      branch = branch.replace('*', '')
+      branch = branch.trim()
+
+      return resolve(branch)
+    })
+  })
+}
+
+currentBranch().then(branch => {
+  console.log('Checking branch name...')
+
+  if (branch !== 'master' &&
+    branch !== 'develop' &&
+    !/^feature\//.test(branch) &&
+    !/^patch\//.test(branch) &&
+    !/^release-/.test(branch)
+  ) {
+    console.log()
+    console.log('Branch name invalid.')
+    console.log('Please use topic branches named "feature/...", or "patch/..."')
+    console.log()
+
+    process.exit(1)
+  } else {
+    console.log('Branch name OK.')
+    process.exit(0)
+  }
+})


### PR DESCRIPTION
This PR introduces a script to be run as a precommit hook to ensure the current branch name matches one of the allowed feature/patch/release/develop/master