### PR TITLE
Add media field

### DIFF
--- a/dadi/lib/controller/media.js
+++ b/dadi/lib/controller/media.js
@@ -353,7 +353,7 @@ MediaController.prototype.post = function (req, res, next) {
             req,
             update: response,
             validate: false
-          })          
+          })
         }).then(response => {
           response.results = response.results.map(document => {
             return mediaModel.formatDocuments(document)
@@ -428,7 +428,7 @@ MediaController.prototype.processFile = function ({
     mimeType
   })
   let outputStream = new PassThrough()
-  
+
   stream.pipe(outputStream)
 
   // Setting up any additional streams based on MIME type.

--- a/dadi/lib/controller/media.js
+++ b/dadi/lib/controller/media.js
@@ -425,7 +425,11 @@ MediaController.prototype.processFile = function ({
   let queue = Promise.resolve({
     contentLength: data.length,
     fileName,
-    mimeType
+    mimeType,
+
+    // (!) For backward compatibility. To be removed in
+    // version 5.0.0. ¯\_(ツ)_/¯
+    mimetype: mimeType
   })
   let outputStream = new PassThrough()
 

--- a/dadi/lib/fields/media.js
+++ b/dadi/lib/fields/media.js
@@ -1,0 +1,84 @@
+module.exports.type = 'media'
+
+module.exports.beforeOutput = function ({
+  client,
+  config,
+  field,
+  input,
+  schema
+}) {
+  let bucket = (schema.settings && schema.settings.mediaBucket) || config.get('media.defaultBucket')
+  let model = this.getForeignModel(bucket)
+
+  if (!model) {
+    return input
+  }
+
+  let isArraySyntax = Array.isArray(input[field])
+  let normalisedValue = isArraySyntax ? input[field] : [input[field]]
+  let mediaObjectIDs = normalisedValue.map(value => {
+    if (typeof value !== 'string') {
+      return value._id
+    }
+
+    return value
+  }).filter(Boolean)
+
+  if (mediaObjectIDs.length === 0) {
+    return input
+  }
+
+  return model.get({
+    client,
+    query: {
+      _id: {
+        $in: mediaObjectIDs
+      }
+    }
+  }).then(({results}) => {
+    return results.reduce((mediaObjects, result) => {
+      mediaObjects[result._id] = result
+
+      return mediaObjects
+    }, {})
+  }).then(mediaObjects => {
+    return normalisedValue.map(value => {
+      if (mediaObjects[value._id]) {
+        let mergedValue = Object.assign({}, mediaObjects[value._id], value)
+        let sortedValue = Object.keys(mergedValue).sort().reduce((sortedValue, field) => {
+          sortedValue[field] = mergedValue[field]
+
+          return sortedValue
+        }, {})
+
+        return sortedValue
+      }
+
+      return value
+    })
+  }).then(composedValue => {
+    return Object.assign(input, {
+      [field]: isArraySyntax ? composedValue : composedValue[0]
+    })
+  })
+}
+
+module.exports.beforeSave = function ({
+  field,
+  input
+}) {
+  let isArraySyntax = Array.isArray(input[field])
+  let normalisedValue = (isArraySyntax ? input[field] : [input[field]]).map(value => {
+    if (typeof value === 'string') {
+      return {
+        _id: value
+      }
+    }
+
+    return value
+  })
+
+  return {
+    [field]: isArraySyntax ? normalisedValue : normalisedValue[0]
+  }
+}

--- a/dadi/lib/model/collections/create.js
+++ b/dadi/lib/model/collections/create.js
@@ -68,10 +68,7 @@ function create ({
       documents,
       schema
     }).catch(errors => {
-      let error = this._createValidationError('Validation Failed')
-
-      error.success = false
-      error.errors = errors
+      let error = this._createValidationError('Validation Failed', errors)
 
       return Promise.reject(error)
     })

--- a/features.json
+++ b/features.json
@@ -2,5 +2,6 @@
   "aclv1",
   "i18nv1",
   "i18nv2",
-  "collectionsv1"
+  "collectionsv1",
+  "validationv1"
 ]

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     ]
   },
   "dependencies": {
-    "@dadi/api-validator": "^1.0.0",
+    "@dadi/api-validator": "^1.1.0",
     "@dadi/boot": "^1.1.3",
     "@dadi/cache": "^3.0.0",
     "@dadi/et": "^2.0.0",

--- a/package.json
+++ b/package.json
@@ -46,7 +46,6 @@
     "jsonwebtoken": "^8.0.0",
     "langs": "^2.0.0",
     "length-stream": "^0.1.1",
-    "mime": "^2.3.1",
     "mkdirp": "^0.5.1",
     "moment": "2.19.3",
     "natural": "^0.6.1",

--- a/package.json
+++ b/package.json
@@ -61,7 +61,6 @@
     "streamifier": "^0.1.1",
     "underscore": "1.8.3",
     "underscore-contrib": "^0.3.0",
-    "validator": "9.4.1",
     "vary": "^1.1.2"
   },
   "devDependencies": {

--- a/test/acceptance/fields/datetime.js
+++ b/test/acceptance/fields/datetime.js
@@ -13,7 +13,7 @@ let bearerToken
 let configBackup = config.get()
 let connectionString = 'http://' + config.get('server.host') + ':' + config.get('server.port')
 
-describe.only('DateTime Field', function () {
+describe('DateTime Field', function () {
   before(() => {
     config.set('paths.collections', 'test/acceptance/temp-workspace/collections')
   })

--- a/test/acceptance/fields/media.js
+++ b/test/acceptance/fields/media.js
@@ -1,0 +1,552 @@
+const should = require('should')
+const sinon = require('sinon')
+const fs = require('fs')
+const path = require('path')
+const request = require('supertest')
+const config = require(__dirname + '/../../../config')
+const help = require(__dirname + '/../help')
+const app = require(__dirname + '/../../../dadi/lib/')
+const Model = require('./../../../dadi/lib/model')
+
+let bearerToken
+let configBackup = config.get()
+let client = request(`http://${config.get('server.host')}:${config.get('server.port')}`)
+
+describe.only('Media field', () => {
+  beforeEach(done => {
+    help.dropDatabase('testdb', err => {
+      app.start(() => {
+        help.getBearerToken((err, token) => {
+          bearerToken = token
+
+          done(err)
+        })
+      })
+    })
+  })
+
+  afterEach(done => {
+    app.stop(done)
+  })
+
+  describe('Single value', () => {
+    describe('POST', () => {
+      it('should reject a string value that is not an hexadecimal ID', done => {
+        client
+        .post('/vtest/testdb/test-schema')
+        .set('content-type', 'application/json')
+        .set('Authorization', `Bearer ${bearerToken}`)
+        .send({
+          leadImage: 'QWERTYUIOP'
+        })
+        .expect(400)
+        .end((err, res) => {
+          res.body.success.should.eql(false)
+          res.body.errors[0].field.should.eql('leadImage')
+          res.body.errors[0].code.should.eql('ERROR_VALUE_INVALID')
+
+          done(err)
+        })
+      })
+
+      it('should accept a media object ID as a string', done => {
+        client
+        .post('/media/upload')
+        .set('content-type', 'application/json')
+        .set('Authorization', `Bearer ${bearerToken}`)
+        .attach('avatar', 'test/acceptance/temp-workspace/media/1f525.png')
+        .end((err, res) => {
+          let mediaObject = res.body.results[0]
+          let payload = {
+            title: 'Media support in DADI API',
+            leadImage: mediaObject._id
+          }
+
+          client
+          .post('/vtest/testdb/test-schema')
+          .set('content-type', 'application/json')
+          .set('Authorization', `Bearer ${bearerToken}`)
+          .send(payload)
+          .end((err, res) => {
+            let {results} = res.body
+            
+            results.should.be.instanceOf(Array)
+            results.length.should.eql(1)
+            results[0].title.should.eql(payload.title)
+            results[0].leadImage._id.should.eql(mediaObject._id)
+            results[0].leadImage.fileName.should.eql('1f525.png')
+
+            client
+            .get(`/vtest/testdb/test-schema/${results[0]._id}`)
+            .set('content-type', 'application/json')
+            .set('Authorization', `Bearer ${bearerToken}`)
+            .end((err, res) => {
+              let {results} = res.body
+              
+              results.should.be.instanceOf(Array)
+              results.length.should.eql(1)
+              results[0].title.should.eql(payload.title)
+              results[0].leadImage._id.should.eql(mediaObject._id)
+              results[0].leadImage.fileName.should.eql('1f525.png')
+
+              done(err)
+            })
+          })
+        })
+      })
+
+      it('should reject an object value that does not contain an hexadecimal ID', done => {
+        client
+        .post('/vtest/testdb/test-schema')
+        .set('content-type', 'application/json')
+        .set('Authorization', `Bearer ${bearerToken}`)
+        .send({
+          leadImage: {
+            someProperty: 'Some value'
+          }
+        })
+        .expect(400)
+        .end((err, res) => {
+          res.body.success.should.eql(false)
+          res.body.errors[0].field.should.eql('leadImage')
+          res.body.errors[0].code.should.eql('ERROR_VALUE_INVALID')
+
+          client
+          .post('/vtest/testdb/test-schema')
+          .set('content-type', 'application/json')
+          .set('Authorization', `Bearer ${bearerToken}`)
+          .send({
+            leadImage: {
+              _id: 'QWERTYUIOP',
+              someProperty: 'Some value'
+            }
+          })
+          .expect(400)
+          .end((err, res) => {
+            res.body.success.should.eql(false)
+            res.body.errors[0].field.should.eql('leadImage')
+            res.body.errors[0].code.should.eql('ERROR_VALUE_INVALID')
+
+            done(err)
+          })
+        })
+      })
+      
+      it('should accept a media object as an object', done => {
+        client
+        .post('/media/upload')
+        .set('content-type', 'application/json')
+        .set('Authorization', `Bearer ${bearerToken}`)
+        .attach('avatar', 'test/acceptance/temp-workspace/media/1f525.png')
+        .end((err, res) => {
+          let mediaObject = res.body.results[0]
+          let payload = {
+            title: 'Media support in DADI API',
+            leadImage: {
+              _id: mediaObject._id
+            }
+          }
+
+          client
+          .post('/vtest/testdb/test-schema')
+          .set('content-type', 'application/json')
+          .set('Authorization', `Bearer ${bearerToken}`)
+          .send(payload)
+          .end((err, res) => {
+            let {results} = res.body
+            
+            results.should.be.instanceOf(Array)
+            results.length.should.eql(1)
+            results[0].title.should.eql(payload.title)
+            results[0].leadImage._id.should.eql(mediaObject._id)
+            results[0].leadImage.fileName.should.eql('1f525.png')
+
+            client
+            .get(`/vtest/testdb/test-schema/${results[0]._id}`)
+            .set('content-type', 'application/json')
+            .set('Authorization', `Bearer ${bearerToken}`)
+            .end((err, res) => {
+              let {results} = res.body
+              
+              results.should.be.instanceOf(Array)
+              results.length.should.eql(1)
+              results[0].title.should.eql(payload.title)
+              results[0].leadImage._id.should.eql(mediaObject._id)
+              results[0].leadImage.fileName.should.eql('1f525.png')
+
+              done(err)
+            })
+          })
+        })
+      })
+
+      it('should accept a media object as an object with additional metadata', done => {
+        client
+        .post('/media/upload')
+        .set('content-type', 'application/json')
+        .set('Authorization', `Bearer ${bearerToken}`)
+        .attach('avatar', 'test/acceptance/temp-workspace/media/1f525.png')
+        .end((err, res) => {
+          let mediaObject = res.body.results[0]
+          let payload = {
+            title: 'Media support in DADI API',
+            leadImage: {
+              _id: mediaObject._id,
+              altText: 'A diagram outlining media support in DADI API',
+              crop: [16, 32, 64, 128]
+            }
+          }
+
+          client
+          .post('/vtest/testdb/test-schema')
+          .set('content-type', 'application/json')
+          .set('Authorization', `Bearer ${bearerToken}`)
+          .send(payload)
+          .end((err, res) => {
+            let {results} = res.body
+
+            results.should.be.instanceOf(Array)
+            results.length.should.eql(1)
+            results[0].title.should.eql(payload.title)
+            results[0].leadImage._id.should.eql(mediaObject._id)
+            results[0].leadImage.altText.should.eql(payload.leadImage.altText)
+            results[0].leadImage.crop.should.eql(payload.leadImage.crop)
+            results[0].leadImage.fileName.should.eql('1f525.png')
+
+            client
+            .post(`/vtest/testdb/test-schema/${results[0]._id}`)
+            .set('content-type', 'application/json')
+            .set('Authorization', `Bearer ${bearerToken}`)
+            .send(payload)
+            .end((err, res) => {
+              let {results} = res.body
+
+              results.should.be.instanceOf(Array)
+              results.length.should.eql(1)
+              results[0].title.should.eql(payload.title)
+              results[0].leadImage._id.should.eql(mediaObject._id)
+              results[0].leadImage.altText.should.eql(payload.leadImage.altText)
+              results[0].leadImage.crop.should.eql(payload.leadImage.crop)
+              results[0].leadImage.fileName.should.eql('1f525.png')
+
+              done(err)
+            })
+          })
+        })
+      })
+    })
+
+    describe('PUT', () => {
+      it('should reject a string that isn\'t a hexadecimal ID', done => {
+        client
+        .post('/media/upload')
+        .set('content-type', 'application/json')
+        .set('Authorization', `Bearer ${bearerToken}`)
+        .attach('avatar', 'test/acceptance/temp-workspace/media/1f525.png')
+        .end((err, res) => {
+          let mediaObject = res.body.results[0]
+          let payload = {
+            title: 'Media support in DADI API',
+            leadImage: mediaObject._id
+          }
+
+          client
+          .post('/vtest/testdb/test-schema')
+          .set('content-type', 'application/json')
+          .set('Authorization', `Bearer ${bearerToken}`)
+          .send(payload)
+          .end((err, res) => {
+            let {results} = res.body
+            
+            results.should.be.instanceOf(Array)
+            results.length.should.eql(1)
+            results[0].title.should.eql(payload.title)
+            results[0].leadImage._id.should.eql(mediaObject._id)
+            results[0].leadImage.fileName.should.eql('1f525.png')
+
+            let updatePayload = {
+              leadImage: 'QWERTYUIOP'
+            }
+
+            client
+            .put(`/vtest/testdb/test-schema/${results[0]._id}`)
+            .set('content-type', 'application/json')
+            .set('Authorization', `Bearer ${bearerToken}`)
+            .send(updatePayload)
+            .expect(400)
+            .end((err, res) => {
+              res.body.success.should.eql(false)
+              res.body.errors[0].field.should.eql('leadImage')
+              res.body.errors[0].code.should.eql('ERROR_VALUE_INVALID')
+
+              done(err)
+            })
+          })
+        })
+      })
+
+      it('should accept a media object ID as a string', done => {
+        client
+        .post('/media/upload')
+        .set('content-type', 'application/json')
+        .set('Authorization', `Bearer ${bearerToken}`)
+        .attach('avatar', 'test/acceptance/temp-workspace/media/1f525.png')
+        .end((err, res) => {
+          let mediaObject1 = res.body.results[0]
+
+          client
+          .post('/media/upload')
+          .set('content-type', 'application/json')
+          .set('Authorization', `Bearer ${bearerToken}`)
+          .attach('avatar', 'test/acceptance/temp-workspace/media/flowers.jpg')
+          .end((err, res) => {
+            let mediaObject2 = res.body.results[0]
+            let payload = {
+              title: 'Media support in DADI API',
+              leadImage: mediaObject1._id
+            }
+
+            client
+            .post('/vtest/testdb/test-schema')
+            .set('content-type', 'application/json')
+            .set('Authorization', `Bearer ${bearerToken}`)
+            .send(payload)
+            .end((err, res) => {
+              let {results} = res.body
+              
+              results.should.be.instanceOf(Array)
+              results.length.should.eql(1)
+              results[0].title.should.eql(payload.title)
+              results[0].leadImage._id.should.eql(mediaObject1._id)
+              results[0].leadImage.fileName.should.eql('1f525.png')
+
+              let updatePayload = {
+                leadImage: mediaObject2._id
+              }
+
+              client
+              .put(`/vtest/testdb/test-schema/${results[0]._id}`)
+              .set('content-type', 'application/json')
+              .set('Authorization', `Bearer ${bearerToken}`)
+              .send(updatePayload)
+              .end((err, res) => {
+                client
+                .get(`/vtest/testdb/test-schema/${results[0]._id}`)
+                .set('content-type', 'application/json')
+                .set('Authorization', `Bearer ${bearerToken}`)
+                .end((err, res) => {
+                  let {results} = res.body
+
+                  results.should.be.instanceOf(Array)
+                  results.length.should.eql(1)
+                  results[0].title.should.eql(payload.title)
+                  results[0].leadImage._id.should.eql(mediaObject2._id)
+                  results[0].leadImage.fileName.should.eql('flowers.jpg')
+
+                  done(err)
+                })
+              })
+            })
+          })
+        })
+      })
+
+      it('should reject an object that doesn\'t contain a hexadecimal ID', done => {
+        client
+        .post('/media/upload')
+        .set('content-type', 'application/json')
+        .set('Authorization', `Bearer ${bearerToken}`)
+        .attach('avatar', 'test/acceptance/temp-workspace/media/1f525.png')
+        .end((err, res) => {
+          let mediaObject = res.body.results[0]
+          let payload = {
+            title: 'Media support in DADI API',
+            leadImage: mediaObject._id
+          }
+
+          client
+          .post('/vtest/testdb/test-schema')
+          .set('content-type', 'application/json')
+          .set('Authorization', `Bearer ${bearerToken}`)
+          .send(payload)
+          .end((err, res) => {
+            let {results} = res.body
+            
+            results.should.be.instanceOf(Array)
+            results.length.should.eql(1)
+            results[0].title.should.eql(payload.title)
+            results[0].leadImage._id.should.eql(mediaObject._id)
+            results[0].leadImage.fileName.should.eql('1f525.png')
+
+            let updatePayload = {
+              leadImage: {
+                _id: 'QWERTYUIOP'
+              }
+            }
+
+            client
+            .put(`/vtest/testdb/test-schema/${results[0]._id}`)
+            .set('content-type', 'application/json')
+            .set('Authorization', `Bearer ${bearerToken}`)
+            .send(updatePayload)
+            .expect(400)
+            .end((err, res) => {
+              res.body.success.should.eql(false)
+              res.body.errors[0].field.should.eql('leadImage')
+              res.body.errors[0].code.should.eql('ERROR_VALUE_INVALID')
+
+              done(err)
+            })
+          })
+        })
+      })
+
+      it('should accept a media object ID as an object', done => {
+        client
+        .post('/media/upload')
+        .set('content-type', 'application/json')
+        .set('Authorization', `Bearer ${bearerToken}`)
+        .attach('avatar', 'test/acceptance/temp-workspace/media/1f525.png')
+        .end((err, res) => {
+          let mediaObject1 = res.body.results[0]
+
+          client
+          .post('/media/upload')
+          .set('content-type', 'application/json')
+          .set('Authorization', `Bearer ${bearerToken}`)
+          .attach('avatar', 'test/acceptance/temp-workspace/media/flowers.jpg')
+          .end((err, res) => {
+            let mediaObject2 = res.body.results[0]
+            let payload = {
+              title: 'Media support in DADI API',
+              leadImage: mediaObject1._id
+            }
+
+            client
+            .post('/vtest/testdb/test-schema')
+            .set('content-type', 'application/json')
+            .set('Authorization', `Bearer ${bearerToken}`)
+            .send(payload)
+            .end((err, res) => {
+              let {results} = res.body
+              
+              results.should.be.instanceOf(Array)
+              results.length.should.eql(1)
+              results[0].title.should.eql(payload.title)
+              results[0].leadImage._id.should.eql(mediaObject1._id)
+              results[0].leadImage.fileName.should.eql('1f525.png')
+
+              let updatePayload = {
+                leadImage: {
+                  _id: mediaObject2._id
+                }
+              }
+
+              client
+              .put(`/vtest/testdb/test-schema/${results[0]._id}`)
+              .set('content-type', 'application/json')
+              .set('Authorization', `Bearer ${bearerToken}`)
+              .send(updatePayload)
+              .end((err, res) => {
+                client
+                .get(`/vtest/testdb/test-schema/${results[0]._id}`)
+                .set('content-type', 'application/json')
+                .set('Authorization', `Bearer ${bearerToken}`)
+                .end((err, res) => {
+                  let {results} = res.body
+
+                  results.should.be.instanceOf(Array)
+                  results.length.should.eql(1)
+                  results[0].title.should.eql(payload.title)
+                  results[0].leadImage._id.should.eql(mediaObject2._id)
+                  results[0].leadImage.fileName.should.eql('flowers.jpg')
+
+                  done(err)
+                })
+              })
+            })
+          })
+        })
+      })
+
+      it('should accept a media object ID as an object with additional metadata', done => {
+        client
+        .post('/media/upload')
+        .set('content-type', 'application/json')
+        .set('Authorization', `Bearer ${bearerToken}`)
+        .attach('avatar', 'test/acceptance/temp-workspace/media/1f525.png')
+        .end((err, res) => {
+          let mediaObject1 = res.body.results[0]
+
+          client
+          .post('/media/upload')
+          .set('content-type', 'application/json')
+          .set('Authorization', `Bearer ${bearerToken}`)
+          .attach('avatar', 'test/acceptance/temp-workspace/media/flowers.jpg')
+          .end((err, res) => {
+            let mediaObject2 = res.body.results[0]
+            let payload = {
+              title: 'Media support in DADI API',
+              leadImage: {
+                _id: mediaObject1._id,
+                altText: 'Original alt text',
+                caption: 'Original caption'
+              }
+            }
+
+            client
+            .post('/vtest/testdb/test-schema')
+            .set('content-type', 'application/json')
+            .set('Authorization', `Bearer ${bearerToken}`)
+            .send(payload)
+            .end((err, res) => {
+              let {results} = res.body
+              
+              results.should.be.instanceOf(Array)
+              results.length.should.eql(1)
+              results[0].title.should.eql(payload.title)
+              results[0].leadImage._id.should.eql(mediaObject1._id)
+              results[0].leadImage.altText.should.eql(payload.leadImage.altText)
+              results[0].leadImage.caption.should.eql(payload.leadImage.caption)
+              results[0].leadImage.fileName.should.eql('1f525.png')
+
+              let updatePayload = {
+                leadImage: {
+                  _id: mediaObject2._id,
+                  altText: 'New alt text',
+                  crop: [16, 32, 64, 128]
+                }
+              }
+
+              client
+              .put(`/vtest/testdb/test-schema/${results[0]._id}`)
+              .set('content-type', 'application/json')
+              .set('Authorization', `Bearer ${bearerToken}`)
+              .send(updatePayload)
+              .end((err, res) => {
+                client
+                .get(`/vtest/testdb/test-schema/${results[0]._id}`)
+                .set('content-type', 'application/json')
+                .set('Authorization', `Bearer ${bearerToken}`)
+                .end((err, res) => {
+                  let {results} = res.body
+
+                  results.should.be.instanceOf(Array)
+                  results.length.should.eql(1)
+                  results[0].title.should.eql(payload.title)
+                  results[0].leadImage._id.should.eql(mediaObject2._id)
+                  results[0].leadImage.altText.should.eql(updatePayload.leadImage.altText)
+                  results[0].leadImage.crop.should.eql(updatePayload.leadImage.crop)
+                  should.not.exist(results[0].leadImage.caption)
+                  results[0].leadImage.fileName.should.eql('flowers.jpg')
+
+                  done(err)
+                })
+              })
+            })
+          })
+        })
+      })
+    })
+  })
+})

--- a/test/acceptance/fields/media.js
+++ b/test/acceptance/fields/media.js
@@ -12,7 +12,7 @@ let bearerToken
 let configBackup = config.get()
 let client = request(`http://${config.get('server.host')}:${config.get('server.port')}`)
 
-describe.only('Media field', () => {
+describe('Media field', () => {
   beforeEach(done => {
     help.dropDatabase('testdb', err => {
       app.start(() => {

--- a/test/acceptance/media.js
+++ b/test/acceptance/media.js
@@ -302,7 +302,7 @@ describe('Media', function () {
           res.body.results.length.should.eql(1)
 
           res.body.results[0].fileName.should.eql(obj.fileName)
-          res.body.results[0].mimetype.should.eql(obj.mimetype)
+          res.body.results[0].mimeType.should.eql(obj.mimetype)
           res.body.results[0].width.should.eql(512)
           res.body.results[0].height.should.eql(512)
 
@@ -315,7 +315,7 @@ describe('Media', function () {
           .attach('avatar', 'test/acceptance/temp-workspace/media/flowers.jpg')
           .end((err, res) => {
             res.body.results[0].fileName.should.eql('flowers.jpg')
-            res.body.results[0].mimetype.should.eql('image/jpeg')
+            res.body.results[0].mimeType.should.eql('image/jpeg')
             res.body.results[0].width.should.eql(1600)
             res.body.results[0].height.should.eql(1086)
 
@@ -325,7 +325,7 @@ describe('Media', function () {
             .set('Authorization', `Bearer ${bearerToken}`)
             .end((err, res) => {
               res.body.results[0].fileName.should.eql('flowers.jpg')
-              res.body.results[0].mimetype.should.eql('image/jpeg')
+              res.body.results[0].mimeType.should.eql('image/jpeg')
               res.body.results[0].width.should.eql(1600)
               res.body.results[0].height.should.eql(1086)
 

--- a/test/acceptance/workspace/collections/vtest/testdb/collection.test-schema.json
+++ b/test/acceptance/workspace/collections/vtest/testdb/collection.test-schema.json
@@ -16,7 +16,10 @@
       "search": {
         "weight": 2
       }
-    }
+    },
+    "leadImage": {
+      "type": "Media"
+    }    
   },
   "settings": {
     "cache": true,


### PR DESCRIPTION
*Tick once reviewed*

- [x] Remove reliance on `mime` package and instead use the MIME type information passed on by `busboy`
- [x] Reorganise media controller and introduce a `processFile` method that prepares a basic response object with properties that are common to every file type plus any additional metadata properties specific to the MIME type being processed (currently only `image/jpeg` and `image/png`)