### PR TITLE
Allow bulk upload of media files + deleting by query

### DIFF
--- a/test/acceptance/media.js
+++ b/test/acceptance/media.js
@@ -287,6 +287,29 @@ describe('Media', function () {
             done()
           })
         })
+
+        it('should return an error when uploading multiple files', function (done) {
+          client
+          .post('/media/sign')
+          .set('Authorization', `Bearer ${bearerToken}`)
+          .set('content-type', 'application/json')
+          .send({})
+          .end((err, res) => {
+            if (err) return (err)
+
+            client
+            .post(res.body.url)
+            .set('content-type', 'application/json')
+            .attach('avatar', 'test/acceptance/temp-workspace/media/1f525.png')
+            .attach('avatar', 'test/acceptance/temp-workspace/media/flowers.jpg')
+            .end((err, res) => {
+              res.statusCode.should.eql(400)
+              res.body.errors[0].should.eql('Multiple file upload with signed URLs not supported')
+
+              done(err)
+            })
+          })
+        })
       })
 
       describe('with access token', () => {


### PR DESCRIPTION
This PR allows:

- Uploading multiple media files (when not using a signed URL)
- Deleting multiple media files by sending a `DELETE` request to `/media[/bucket]` with a `query` property in the body, similarly to how document collections work.

Closes #498.