### PR TITLE
Return hook error in afterGet

### DIFF
--- a/dadi/lib/model/collections/get.js
+++ b/dadi/lib/model/collections/get.js
@@ -101,10 +101,16 @@ function get ({
           },
           (error, resultsAfterHooks) => {
             if (error) {
-              error.hook = this.settings.hooks.afterGet
+              let hook = new Hook({
+                hook: this.settings.hooks.afterGet[0]
+              }, 'afterGet')
 
               logger.error({ module: 'model' }, error)
-              return reject(error)
+
+              return resolve({
+                results: hook.formatError(error[0].code),
+                metadata: {}
+              })
             }
 
             resolve(resultsAfterHooks)
@@ -126,8 +132,6 @@ function get ({
     ).then(results => {
       return {results, metadata}
     })
-  }).catch(err => {
-    return err
   })
 }
 

--- a/dadi/lib/model/collections/get.js
+++ b/dadi/lib/model/collections/get.js
@@ -101,8 +101,9 @@ function get ({
           },
           (error, resultsAfterHooks) => {
             if (error) {
-              logger.error({ module: 'model' }, error)
               error.hook = this.settings.hooks.afterGet
+
+              logger.error({ module: 'model' }, error)
               return reject(error)
             }
 

--- a/dadi/lib/model/collections/get.js
+++ b/dadi/lib/model/collections/get.js
@@ -102,6 +102,7 @@ function get ({
           (error, resultsAfterHooks) => {
             if (error) {
               logger.error({ module: 'model' }, error)
+              error.hook = this.settings.hooks.afterGet
               return reject(error)
             }
 

--- a/dadi/lib/model/collections/get.js
+++ b/dadi/lib/model/collections/get.js
@@ -102,6 +102,7 @@ function get ({
           (error, resultsAfterHooks) => {
             if (error) {
               logger.error({ module: 'model' }, error)
+              return reject(error)
             }
 
             resolve(resultsAfterHooks)
@@ -123,6 +124,8 @@ function get ({
     ).then(results => {
       return {results, metadata}
     })
+  }).catch(err => {
+    return err
   })
 }
 

--- a/test/acceptance/fields/number.js
+++ b/test/acceptance/fields/number.js
@@ -1,0 +1,70 @@
+const should = require('should')
+const sinon = require('sinon')
+const request = require('supertest')
+const config = require(__dirname + '/../../../config')
+const help = require(__dirname + '/../help')
+const app = require(__dirname + '/../../../dadi/lib/')
+const Model = require('./../../../dadi/lib/model')
+
+let bearerToken
+let configBackup = config.get()
+let connectionString = 'http://' + config.get('server.host') + ':' + config.get('server.port')
+
+describe('Number Field', () => {
+  beforeEach(done => {
+    config.set('paths.collections', 'test/acceptance/temp-workspace/collections')
+
+    help.dropDatabase('library', 'misc', _err => {
+      app.start(() => {
+        help.getBearerToken(function (err, token) {
+          if (err) return done(err)
+          bearerToken = token
+          done()
+        })
+      })
+    })
+  })
+
+  afterEach(done => {
+    config.set('paths.collections', configBackup.paths.collections)
+    app.stop(done)
+  })
+
+  describe('query filtering', () => {
+    it('should treat a supplied number as a number', done => {
+      let client = request(connectionString)
+      let value = 5000
+
+      client
+      .post('/v1/library/misc')
+      .set('Authorization', 'Bearer ' + bearerToken)
+      .send({number: value})
+      .expect(200)
+      .end((err, res) => {
+        if (err) return done(err)
+
+        let model = Model('misc')
+        let spy = sinon.spy(model.connection.db, 'find')
+
+        let query = JSON.stringify({
+          'number': {
+            '$gt': value
+          }
+        })
+
+        client
+        .get(`/v1/library/misc?filter=${query}`)
+        .set('Authorization', 'Bearer ' + bearerToken)
+        .expect(200)
+        .end((err, res) => {        
+          let query = spy.getCall(0).args[0].query.number
+          query[Object.keys(query)[0]].should.eql(5000)
+
+          spy.restore()
+
+          done()
+        })
+      })
+    })
+  })
+})

--- a/test/acceptance/workspace/collections/v1/library/collection.misc.json
+++ b/test/acceptance/workspace/collections/v1/library/collection.misc.json
@@ -6,6 +6,9 @@
     "mixed": {
       "type": "Mixed"
     },
+    "number": {
+      "type": "Number"
+    },
     "object": {
       "type": "Object"
     },

--- a/test/unit/model/hooks.js
+++ b/test/unit/model/hooks.js
@@ -90,7 +90,7 @@ notInstalledHook += '  let x = notAPackage("X")\n'
 notInstalledHook += '}\n'
 var notInstalledFunction = eval(notInstalledHook)
 
-describe.only('Hook', function () {
+describe('Hook', function () {
   it('should export a constructor', function (done) {
     hook.should.be.Function
     done()

--- a/test/unit/model/hooks.js
+++ b/test/unit/model/hooks.js
@@ -1500,7 +1500,7 @@ describe('Hook', function () {
 
           hook.Hook.prototype.load.restore()
 
-          doc[0].code.indexOf('Cannot find module').should.be.above(0)
+          doc.results[0].details.indexOf('Cannot find module').should.be.above(0)
 
           done()
         })


### PR DESCRIPTION
This PR returns an error to the consumer if an afterGet hook fails:

```
{ results:
   [ { code: 'API-0002',
       details:
        'notInstalled - API-Error: Cannot find module \'not-a-package\'',
       docLink: 'https://docs.dadi.cloud/api/#api-0002',
       hookName: 'notInstalled',
       title: 'Hook Error' } ],
  metadata: {} }
```

Close #419 

