### PR TITLE
Add mimeType validation and composed property to Media field

### DIFF
--- a/dadi/lib/fields/media.js
+++ b/dadi/lib/fields/media.js
@@ -23,6 +23,7 @@ module.exports.beforeOutput = function ({
 
     return value
   }).filter(Boolean)
+  let composedIDs = []
 
   if (mediaObjectIDs.length === 0) {
     return input
@@ -51,21 +52,33 @@ module.exports.beforeOutput = function ({
           return sortedValue
         }, {})
 
+        composedIDs.push(value._id)
+
         return sortedValue
       }
 
-      return value
+      return value._id
     })
   }).then(composedValue => {
-    return Object.assign(input, {
+    let output = Object.assign(input, {
       [field]: isArraySyntax ? composedValue : composedValue[0]
     })
+
+    if (composedIDs.length > 0) {
+      output._composed = {
+        [field]: isArraySyntax ? composedIDs : composedIDs[0]
+      }
+    }
+
+    return output
   })
 }
 
 module.exports.beforeSave = function ({
+  config,
   field,
-  input
+  input,
+  schema
 }) {
   let isArraySyntax = Array.isArray(input[field])
   let normalisedValue = (isArraySyntax ? input[field] : [input[field]]).map(value => {
@@ -77,8 +90,57 @@ module.exports.beforeSave = function ({
 
     return value
   })
+  let queue = Promise.resolve()
 
-  return {
-    [field]: isArraySyntax ? normalisedValue : normalisedValue[0]
+  // If there is a validation block with a `mimeTypes` property, it means we
+  // need to ensure that the IDs supplied correspond to valid media objects
+  // with a certain MIME type. As a result, we must:
+  //
+  // 1) Identify the media bucket and get the corresponding model;
+  // 2) Grab the media objects referenced by the IDs;
+  // 3) Look for any item on that list that doesn't exist, doesn't have a MIME
+  //    type or has one that isn't included in the list of valid MIME types;
+  // 4) Reject the request if the list produced in 3) is not empty.
+  if (schema.validation && Array.isArray(schema.validation.mimeTypes)) {
+    let allowedMimeTypes = schema.validation.mimeTypes
+    let bucketName = (schema.settings && schema.settings.mediaBucket) ||
+      config.get('media.defaultBucket')
+    let model = this.getForeignModel(bucketName)
+
+    queue = queue.then(() => {
+      return model.find({
+        query: {
+          _id: {
+            $in: normalisedValue.map(item => item._id)
+          }
+        }
+      }).then(({results}) => {
+        if (results.length < normalisedValue.length) {
+          let error = new Error('has one or more values that do not match valid media objects')
+
+          error.code = 'ERROR_INVALID_ID'
+
+          return Promise.reject(error)
+        }
+
+        let invalidResults = results.find(result => {
+          let mimeType = result.mimeType || result.mimetype
+
+          return !mimeType || !allowedMimeTypes.includes(mimeType)
+        })
+
+        if (invalidResults) {
+          let error = new Error(`has invalid MIME type. Expected: ${allowedMimeTypes.join(', ')}`)
+
+          error.code = 'ERROR_INVALID_MIME_TYPE'
+
+          return Promise.reject(error)
+        }
+      })
+    })
   }
+
+  return queue.then(() => ({
+    [field]: isArraySyntax ? normalisedValue : normalisedValue[0]
+  }))
 }

--- a/dadi/lib/model/collections/create.js
+++ b/dadi/lib/model/collections/create.js
@@ -105,16 +105,6 @@ function create ({
             name: 'beforeSave'
           }).then(subDocument => {
             return Object.assign({}, transformedDocument, subDocument)
-          }).catch(error => {
-            error.success = false
-            error.errors = [
-              {
-                field,
-                message: error.message
-              }
-            ]
-
-            return Promise.reject(error)
           })
         })
       }, Promise.resolve({}))

--- a/dadi/lib/model/index.js
+++ b/dadi/lib/model/index.js
@@ -644,17 +644,19 @@ Model.prototype.runFieldHooks = function ({
   })
 
   return queue.catch(error => {
-    let errorData = [
-      {
-        field,
-        message: error.message
-      }
-    ]
+    let errorObject = {
+      field,
+      message: error.message
+    }
+
+    if (error.code) {
+      errorObject.code = error.code
+    }
 
     logger.error({module: 'field hooks'}, error)
 
     return Promise.reject(
-      this._createValidationError('Validation failed', errorData)
+      this._createValidationError('Validation failed', [errorObject])
     )
   })
 }

--- a/test/acceptance/fields/media.js
+++ b/test/acceptance/fields/media.js
@@ -29,15 +29,360 @@ describe('Media field', () => {
     app.stop(done)
   })
 
-  describe('Single value', () => {
-    describe('POST', () => {
-      it('should reject a string value that is not an hexadecimal ID', done => {
+  describe('POST', () => {
+    describe('when `validation.mimeTypes` is defined', () => {
+      it('should reject a single value that does not correspond to a valid media object', done => {
+        let payload = {
+          title: 'Media support in DADI API',
+          leadImageJPEG: '5bf5369dd680048cf051bd92'
+        }
+
+        client
+        .post('/vtest/testdb/test-schema')
+        .set('content-type', 'application/json')
+        .set('Authorization', `Bearer ${bearerToken}`)
+        .expect(400)
+        .send(payload)
+        .end((err, res) => {
+          res.body.success.should.eql(false)
+          res.body.errors.length.should.eql(1)
+          res.body.errors[0].field.should.eql('leadImageJPEG')
+          res.body.errors[0].code.should.eql('ERROR_INVALID_ID')
+          res.body.errors[0].message.should.be.instanceOf(String)
+
+          done(err)
+        })
+      })
+
+      it('should reject a single value that corresponds to a media object with a MIME type that is not allowed', done => {
+        client
+        .post('/media/upload')
+        .set('content-type', 'application/json')
+        .set('Authorization', `Bearer ${bearerToken}`)
+        .attach('avatar', 'test/acceptance/temp-workspace/media/1f525.png')
+        .end((err, res) => {
+          let mediaObject = res.body.results[0]
+          let payload = {
+            title: 'Media support in DADI API',
+            leadImageJPEG: mediaObject._id
+          }
+
+          client
+          .post('/vtest/testdb/test-schema')
+          .set('content-type', 'application/json')
+          .set('Authorization', `Bearer ${bearerToken}`)
+          .expect(400)
+          .send(payload)
+          .end((err, res) => {
+            res.body.success.should.eql(false)
+            res.body.errors.length.should.eql(1)
+            res.body.errors[0].field.should.eql('leadImageJPEG')
+            res.body.errors[0].code.should.eql('ERROR_INVALID_MIME_TYPE')
+            res.body.errors[0].message.should.be.instanceOf(String)
+
+            done(err)
+          })
+        })
+      })
+
+      it('should accept a single value that corresponds to a media object with a MIME type that is allowed', done => {
+        client
+        .post('/media/upload')
+        .set('content-type', 'application/json')
+        .set('Authorization', `Bearer ${bearerToken}`)
+        .attach('avatar', 'test/acceptance/temp-workspace/media/flowers.jpg')
+        .end((err, res) => {
+          let mediaObject = res.body.results[0]
+          let payload = {
+            title: 'Media support in DADI API',
+            leadImageJPEG: mediaObject._id
+          }
+
+          client
+          .post('/vtest/testdb/test-schema')
+          .set('content-type', 'application/json')
+          .set('Authorization', `Bearer ${bearerToken}`)
+          .expect(200)
+          .send(payload)
+          .end((err, res) => {
+            res.body.results.should.be.instanceOf(Array)
+            res.body.results.length.should.eql(1)
+            res.body.results[0].title.should.eql(payload.title)
+            res.body.results[0].leadImageJPEG._id.should.eql(mediaObject._id)
+            res.body.results[0].leadImageJPEG.fileName.should.eql('flowers.jpg')
+            res.body.results[0]._composed.leadImageJPEG.should.eql(mediaObject._id)
+
+            done(err)
+          })
+        })
+      })
+
+      it('should reject a multiple value where one of the IDs does not correspond to a valid media object', done => {
+        client
+        .post('/media/upload')
+        .set('content-type', 'application/json')
+        .set('Authorization', `Bearer ${bearerToken}`)
+        .attach('avatar', 'test/acceptance/temp-workspace/media/1f525.png')
+        .end((err, res) => {
+          let mediaObject = res.body.results[0]
+          let payload = {
+            title: 'Media support in DADI API',
+            leadImageJPEG: [
+              '5bf5369dd680048cf051bd92',
+              mediaObject._id
+            ]
+          }
+
+          client
+          .post('/vtest/testdb/test-schema')
+          .set('content-type', 'application/json')
+          .set('Authorization', `Bearer ${bearerToken}`)
+          .expect(400)
+          .send(payload)
+          .end((err, res) => {
+            res.body.success.should.eql(false)
+            res.body.errors.length.should.eql(1)
+            res.body.errors[0].field.should.eql('leadImageJPEG')
+            res.body.errors[0].code.should.eql('ERROR_INVALID_ID')
+            res.body.errors[0].message.should.be.instanceOf(String)
+
+            done(err)
+          })
+        })
+      })
+
+      it('should reject a multiple value where one of the IDs corresponds to a media object with a MIME type that is not allowed', done => {
+        client
+        .post('/media/upload')
+        .set('content-type', 'application/json')
+        .set('Authorization', `Bearer ${bearerToken}`)
+        .attach('avatar', 'test/acceptance/temp-workspace/media/1f525.png')
+        .end((err, res) => {
+          let mediaObject1 = res.body.results[0]
+
+          client
+          .post('/media/upload')
+          .set('content-type', 'application/json')
+          .set('Authorization', `Bearer ${bearerToken}`)
+          .attach('avatar', 'test/acceptance/temp-workspace/media/flowers.jpg')
+          .end((err, res) => {
+            let mediaObject2 = res.body.results[0]
+            let payload = {
+              title: 'Media support in DADI API',
+              leadImageJPEG: [
+                mediaObject1._id,
+                mediaObject2._id
+              ]
+            }
+
+            client
+            .post('/vtest/testdb/test-schema')
+            .set('content-type', 'application/json')
+            .set('Authorization', `Bearer ${bearerToken}`)
+            .expect(400)
+            .send(payload)
+            .end((err, res) => {
+              res.body.success.should.eql(false)
+              res.body.errors.length.should.eql(1)
+              res.body.errors[0].field.should.eql('leadImageJPEG')
+              res.body.errors[0].code.should.eql('ERROR_INVALID_MIME_TYPE')
+              res.body.errors[0].message.should.be.instanceOf(String)
+
+              done(err)
+            })
+          })
+        })
+      })
+    })
+
+    it('should reject a string value that is not an hexadecimal ID', done => {
+      client
+      .post('/vtest/testdb/test-schema')
+      .set('content-type', 'application/json')
+      .set('Authorization', `Bearer ${bearerToken}`)
+      .send({
+        leadImage: 'QWERTYUIOP'
+      })
+      .expect(400)
+      .end((err, res) => {
+        res.body.success.should.eql(false)
+        res.body.errors[0].field.should.eql('leadImage')
+        res.body.errors[0].code.should.eql('ERROR_VALUE_INVALID')
+
+        done(err)
+      })
+    })
+
+    it('should accept an ID that does not correspond to a valid media object', done => {
+      let payload = {
+        title: 'Media support in DADI API',
+        leadImage: '5bf5369dd680048cf051bd92'
+      }
+
+      client
+      .post('/vtest/testdb/test-schema')
+      .set('content-type', 'application/json')
+      .set('Authorization', `Bearer ${bearerToken}`)
+      .expect(200)
+      .send(payload)
+      .end((err, res) => {
+        res.body.results.should.be.instanceOf(Array)
+        res.body.results.length.should.eql(1)
+        res.body.results[0].title.should.eql(payload.title)
+        res.body.results[0].leadImage.should.eql(payload.leadImage)
+        should.not.exist(res.body.results[0]._composed)
+
+        done(err)
+      })
+    })
+
+    it('should accept a media object ID as a string', done => {
+      client
+      .post('/media/upload')
+      .set('content-type', 'application/json')
+      .set('Authorization', `Bearer ${bearerToken}`)
+      .attach('avatar', 'test/acceptance/temp-workspace/media/1f525.png')
+      .end((err, res) => {
+        let mediaObject = res.body.results[0]
+        let payload = {
+          title: 'Media support in DADI API',
+          leadImage: mediaObject._id
+        }
+
+        client
+        .post('/vtest/testdb/test-schema')
+        .set('content-type', 'application/json')
+        .set('Authorization', `Bearer ${bearerToken}`)
+        .send(payload)
+        .end((err, res) => {
+          let {results} = res.body
+          
+          results.should.be.instanceOf(Array)
+          results.length.should.eql(1)
+          results[0].title.should.eql(payload.title)
+          results[0].leadImage._id.should.eql(mediaObject._id)
+          results[0].leadImage.fileName.should.eql('1f525.png')
+          results[0]._composed.leadImage.should.eql(mediaObject._id)
+
+          client
+          .get(`/vtest/testdb/test-schema/${results[0]._id}`)
+          .set('content-type', 'application/json')
+          .set('Authorization', `Bearer ${bearerToken}`)
+          .end((err, res) => {
+            let {results} = res.body
+            
+            results.should.be.instanceOf(Array)
+            results.length.should.eql(1)
+            results[0].title.should.eql(payload.title)
+            results[0].leadImage._id.should.eql(mediaObject._id)
+            results[0].leadImage.fileName.should.eql('1f525.png')
+            results[0]._composed.leadImage.should.eql(mediaObject._id)
+
+            done(err)
+          })
+        })
+      })
+    })
+
+    it('should accept multiple media object IDs as an array of strings', done => {
+      client
+      .post('/media/upload')
+      .set('content-type', 'application/json')
+      .set('Authorization', `Bearer ${bearerToken}`)
+      .attach('avatar', 'test/acceptance/temp-workspace/media/1f525.png')
+      .end((err, res) => {
+        let mediaObject1 = res.body.results[0]
+
+        client
+        .post('/media/upload')
+        .set('content-type', 'application/json')
+        .set('Authorization', `Bearer ${bearerToken}`)
+        .attach('avatar', 'test/acceptance/temp-workspace/media/flowers.jpg')
+        .end((err, res) => {
+          let mediaObject2 = res.body.results[0]
+          let payload = {
+            title: 'Media support in DADI API',
+            leadImage: [
+              mediaObject1._id,
+              mediaObject2._id
+            ]
+          }
+
+          client
+          .post('/vtest/testdb/test-schema')
+          .set('content-type', 'application/json')
+          .set('Authorization', `Bearer ${bearerToken}`)
+          .send(payload)
+          .end((err, res) => {
+            let {results} = res.body
+            
+            results.should.be.instanceOf(Array)
+            results.length.should.eql(1)
+            results[0].title.should.eql(payload.title)
+            results[0].leadImage.should.be.instanceOf(Array)
+            results[0].leadImage.length.should.eql(2)
+            results[0].leadImage[0]._id.should.eql(mediaObject1._id)
+            results[0].leadImage[0].fileName.should.eql('1f525.png')
+            results[0].leadImage[1]._id.should.eql(mediaObject2._id)
+            results[0].leadImage[1].fileName.should.eql('flowers.jpg')
+            results[0]._composed.leadImage.should.eql([
+              mediaObject1._id,
+              mediaObject2._id
+            ])
+
+            client
+            .get(`/vtest/testdb/test-schema/${results[0]._id}`)
+            .set('content-type', 'application/json')
+            .set('Authorization', `Bearer ${bearerToken}`)
+            .end((err, res) => {
+              let {results} = res.body
+              
+              results.should.be.instanceOf(Array)
+              results.length.should.eql(1)
+              results[0].title.should.eql(payload.title)
+              results[0].leadImage.should.be.instanceOf(Array)
+              results[0].leadImage.length.should.eql(2)
+              results[0].leadImage[0]._id.should.eql(mediaObject1._id)
+              results[0].leadImage[0].fileName.should.eql('1f525.png')
+              results[0].leadImage[1]._id.should.eql(mediaObject2._id)
+              results[0].leadImage[1].fileName.should.eql('flowers.jpg')
+              results[0]._composed.leadImage.should.eql([
+                mediaObject1._id,
+                mediaObject2._id
+              ])
+
+              done(err)
+            })
+          })
+        })
+      })
+    })
+
+    it('should reject an object value that does not contain an hexadecimal ID', done => {
+      client
+      .post('/vtest/testdb/test-schema')
+      .set('content-type', 'application/json')
+      .set('Authorization', `Bearer ${bearerToken}`)
+      .send({
+        leadImage: {
+          someProperty: 'Some value'
+        }
+      })
+      .expect(400)
+      .end((err, res) => {
+        res.body.success.should.eql(false)
+        res.body.errors[0].field.should.eql('leadImage')
+        res.body.errors[0].code.should.eql('ERROR_VALUE_INVALID')
+
         client
         .post('/vtest/testdb/test-schema')
         .set('content-type', 'application/json')
         .set('Authorization', `Bearer ${bearerToken}`)
         .send({
-          leadImage: 'QWERTYUIOP'
+          leadImage: {
+            _id: 'QWERTYUIOP',
+            someProperty: 'Some value'
+          }
         })
         .expect(400)
         .end((err, res) => {
@@ -48,25 +393,42 @@ describe('Media field', () => {
           done(err)
         })
       })
+    })
+    
+    it('should accept a media object as an object', done => {
+      client
+      .post('/media/upload')
+      .set('content-type', 'application/json')
+      .set('Authorization', `Bearer ${bearerToken}`)
+      .attach('avatar', 'test/acceptance/temp-workspace/media/1f525.png')
+      .end((err, res) => {
+        let mediaObject = res.body.results[0]
+        let payload = {
+          title: 'Media support in DADI API',
+          leadImage: {
+            _id: mediaObject._id
+          }
+        }
 
-      it('should accept a media object ID as a string', done => {
         client
-        .post('/media/upload')
+        .post('/vtest/testdb/test-schema')
         .set('content-type', 'application/json')
         .set('Authorization', `Bearer ${bearerToken}`)
-        .attach('avatar', 'test/acceptance/temp-workspace/media/1f525.png')
+        .send(payload)
         .end((err, res) => {
-          let mediaObject = res.body.results[0]
-          let payload = {
-            title: 'Media support in DADI API',
-            leadImage: mediaObject._id
-          }
+          let {results} = res.body
+          
+          results.should.be.instanceOf(Array)
+          results.length.should.eql(1)
+          results[0].title.should.eql(payload.title)
+          results[0].leadImage._id.should.eql(mediaObject._id)
+          results[0].leadImage.fileName.should.eql('1f525.png')
+          results[0]._composed.leadImage.should.eql(mediaObject._id)
 
           client
-          .post('/vtest/testdb/test-schema')
+          .get(`/vtest/testdb/test-schema/${results[0]._id}`)
           .set('content-type', 'application/json')
           .set('Authorization', `Bearer ${bearerToken}`)
-          .send(payload)
           .end((err, res) => {
             let {results} = res.body
             
@@ -75,76 +437,36 @@ describe('Media field', () => {
             results[0].title.should.eql(payload.title)
             results[0].leadImage._id.should.eql(mediaObject._id)
             results[0].leadImage.fileName.should.eql('1f525.png')
-
-            client
-            .get(`/vtest/testdb/test-schema/${results[0]._id}`)
-            .set('content-type', 'application/json')
-            .set('Authorization', `Bearer ${bearerToken}`)
-            .end((err, res) => {
-              let {results} = res.body
-              
-              results.should.be.instanceOf(Array)
-              results.length.should.eql(1)
-              results[0].title.should.eql(payload.title)
-              results[0].leadImage._id.should.eql(mediaObject._id)
-              results[0].leadImage.fileName.should.eql('1f525.png')
-
-              done(err)
-            })
-          })
-        })
-      })
-
-      it('should reject an object value that does not contain an hexadecimal ID', done => {
-        client
-        .post('/vtest/testdb/test-schema')
-        .set('content-type', 'application/json')
-        .set('Authorization', `Bearer ${bearerToken}`)
-        .send({
-          leadImage: {
-            someProperty: 'Some value'
-          }
-        })
-        .expect(400)
-        .end((err, res) => {
-          res.body.success.should.eql(false)
-          res.body.errors[0].field.should.eql('leadImage')
-          res.body.errors[0].code.should.eql('ERROR_VALUE_INVALID')
-
-          client
-          .post('/vtest/testdb/test-schema')
-          .set('content-type', 'application/json')
-          .set('Authorization', `Bearer ${bearerToken}`)
-          .send({
-            leadImage: {
-              _id: 'QWERTYUIOP',
-              someProperty: 'Some value'
-            }
-          })
-          .expect(400)
-          .end((err, res) => {
-            res.body.success.should.eql(false)
-            res.body.errors[0].field.should.eql('leadImage')
-            res.body.errors[0].code.should.eql('ERROR_VALUE_INVALID')
+            results[0]._composed.leadImage.should.eql(mediaObject._id)
 
             done(err)
           })
         })
       })
-      
-      it('should accept a media object as an object', done => {
+    })
+
+    it('should accept multiple media object IDs as an array of objects', done => {
+      client
+      .post('/media/upload')
+      .set('content-type', 'application/json')
+      .set('Authorization', `Bearer ${bearerToken}`)
+      .attach('avatar', 'test/acceptance/temp-workspace/media/1f525.png')
+      .end((err, res) => {
+        let mediaObject1 = res.body.results[0]
+
         client
         .post('/media/upload')
         .set('content-type', 'application/json')
         .set('Authorization', `Bearer ${bearerToken}`)
-        .attach('avatar', 'test/acceptance/temp-workspace/media/1f525.png')
+        .attach('avatar', 'test/acceptance/temp-workspace/media/flowers.jpg')
         .end((err, res) => {
-          let mediaObject = res.body.results[0]
+          let mediaObject2 = res.body.results[0]
           let payload = {
             title: 'Media support in DADI API',
-            leadImage: {
-              _id: mediaObject._id
-            }
+            leadImage: [
+              { _id: mediaObject1._id },
+              { _id: mediaObject2._id }
+            ]
           }
 
           client
@@ -158,8 +480,16 @@ describe('Media field', () => {
             results.should.be.instanceOf(Array)
             results.length.should.eql(1)
             results[0].title.should.eql(payload.title)
-            results[0].leadImage._id.should.eql(mediaObject._id)
-            results[0].leadImage.fileName.should.eql('1f525.png')
+            results[0].leadImage.should.be.instanceOf(Array)
+            results[0].leadImage.length.should.eql(2)
+            results[0].leadImage[0]._id.should.eql(mediaObject1._id)
+            results[0].leadImage[0].fileName.should.eql('1f525.png')
+            results[0].leadImage[1]._id.should.eql(mediaObject2._id)
+            results[0].leadImage[1].fileName.should.eql('flowers.jpg')
+            results[0]._composed.leadImage.should.eql([
+              mediaObject1._id,
+              mediaObject2._id
+            ])
 
             client
             .get(`/vtest/testdb/test-schema/${results[0]._id}`)
@@ -171,34 +501,60 @@ describe('Media field', () => {
               results.should.be.instanceOf(Array)
               results.length.should.eql(1)
               results[0].title.should.eql(payload.title)
-              results[0].leadImage._id.should.eql(mediaObject._id)
-              results[0].leadImage.fileName.should.eql('1f525.png')
+              results[0].leadImage.should.be.instanceOf(Array)
+              results[0].leadImage.length.should.eql(2)
+              results[0].leadImage[0]._id.should.eql(mediaObject1._id)
+              results[0].leadImage[0].fileName.should.eql('1f525.png')
+              results[0].leadImage[1]._id.should.eql(mediaObject2._id)
+              results[0].leadImage[1].fileName.should.eql('flowers.jpg')
+              results[0]._composed.leadImage.should.eql([
+                mediaObject1._id,
+                mediaObject2._id
+              ])
 
               done(err)
             })
           })
         })
       })
+    })
 
-      it('should accept a media object as an object with additional metadata', done => {
+    it('should accept a media object as an object with additional metadata', done => {
+      client
+      .post('/media/upload')
+      .set('content-type', 'application/json')
+      .set('Authorization', `Bearer ${bearerToken}`)
+      .attach('avatar', 'test/acceptance/temp-workspace/media/1f525.png')
+      .end((err, res) => {
+        let mediaObject = res.body.results[0]
+        let payload = {
+          title: 'Media support in DADI API',
+          leadImage: {
+            _id: mediaObject._id,
+            altText: 'A diagram outlining media support in DADI API',
+            crop: [16, 32, 64, 128]
+          }
+        }
+
         client
-        .post('/media/upload')
+        .post('/vtest/testdb/test-schema')
         .set('content-type', 'application/json')
         .set('Authorization', `Bearer ${bearerToken}`)
-        .attach('avatar', 'test/acceptance/temp-workspace/media/1f525.png')
+        .send(payload)
         .end((err, res) => {
-          let mediaObject = res.body.results[0]
-          let payload = {
-            title: 'Media support in DADI API',
-            leadImage: {
-              _id: mediaObject._id,
-              altText: 'A diagram outlining media support in DADI API',
-              crop: [16, 32, 64, 128]
-            }
-          }
+          let {results} = res.body
+
+          results.should.be.instanceOf(Array)
+          results.length.should.eql(1)
+          results[0].title.should.eql(payload.title)
+          results[0].leadImage._id.should.eql(mediaObject._id)
+          results[0].leadImage.altText.should.eql(payload.leadImage.altText)
+          results[0].leadImage.crop.should.eql(payload.leadImage.crop)
+          results[0].leadImage.fileName.should.eql('1f525.png')
+          results[0]._composed.leadImage.should.eql(mediaObject._id)
 
           client
-          .post('/vtest/testdb/test-schema')
+          .post(`/vtest/testdb/test-schema/${results[0]._id}`)
           .set('content-type', 'application/json')
           .set('Authorization', `Bearer ${bearerToken}`)
           .send(payload)
@@ -212,22 +568,90 @@ describe('Media field', () => {
             results[0].leadImage.altText.should.eql(payload.leadImage.altText)
             results[0].leadImage.crop.should.eql(payload.leadImage.crop)
             results[0].leadImage.fileName.should.eql('1f525.png')
+            results[0]._composed.leadImage.should.eql(mediaObject._id)
+
+            done(err)
+          })
+        })
+      })
+    })
+
+    it('should accept multiple media object IDs as an array of objects with additional metadata', done => {
+      client
+      .post('/media/upload')
+      .set('content-type', 'application/json')
+      .set('Authorization', `Bearer ${bearerToken}`)
+      .attach('avatar', 'test/acceptance/temp-workspace/media/1f525.png')
+      .end((err, res) => {
+        let mediaObject1 = res.body.results[0]
+
+        client
+        .post('/media/upload')
+        .set('content-type', 'application/json')
+        .set('Authorization', `Bearer ${bearerToken}`)
+        .attach('avatar', 'test/acceptance/temp-workspace/media/flowers.jpg')
+        .end((err, res) => {
+          let mediaObject2 = res.body.results[0]
+          let payload = {
+            title: 'Media support in DADI API',
+            leadImage: [
+              {
+                _id: mediaObject1._id,
+                caption: 'Caption for the first image'
+              },
+              {
+                _id: mediaObject2._id,
+                caption: 'Caption for the second image'
+              }
+            ]
+          }
+
+          client
+          .post('/vtest/testdb/test-schema')
+          .set('content-type', 'application/json')
+          .set('Authorization', `Bearer ${bearerToken}`)
+          .send(payload)
+          .end((err, res) => {
+            let {results} = res.body
+            
+            results.should.be.instanceOf(Array)
+            results.length.should.eql(1)
+            results[0].title.should.eql(payload.title)
+            results[0].leadImage.should.be.instanceOf(Array)
+            results[0].leadImage.length.should.eql(2)
+            results[0].leadImage[0]._id.should.eql(mediaObject1._id)
+            results[0].leadImage[0].fileName.should.eql('1f525.png')
+            results[0].leadImage[0].caption.should.eql(payload.leadImage[0].caption)
+            results[0].leadImage[1]._id.should.eql(mediaObject2._id)
+            results[0].leadImage[1].fileName.should.eql('flowers.jpg')
+            results[0].leadImage[1].caption.should.eql(payload.leadImage[1].caption)
+            results[0]._composed.leadImage.should.eql([
+              mediaObject1._id,
+              mediaObject2._id
+            ])
 
             client
-            .post(`/vtest/testdb/test-schema/${results[0]._id}`)
+            .get(`/vtest/testdb/test-schema/${results[0]._id}`)
             .set('content-type', 'application/json')
             .set('Authorization', `Bearer ${bearerToken}`)
-            .send(payload)
             .end((err, res) => {
               let {results} = res.body
-
+              
               results.should.be.instanceOf(Array)
               results.length.should.eql(1)
               results[0].title.should.eql(payload.title)
-              results[0].leadImage._id.should.eql(mediaObject._id)
-              results[0].leadImage.altText.should.eql(payload.leadImage.altText)
-              results[0].leadImage.crop.should.eql(payload.leadImage.crop)
-              results[0].leadImage.fileName.should.eql('1f525.png')
+              results[0].leadImage.should.be.instanceOf(Array)
+              results[0].leadImage.length.should.eql(2)
+              results[0].leadImage[0]._id.should.eql(mediaObject1._id)
+              results[0].leadImage[0].fileName.should.eql('1f525.png')
+              results[0].leadImage[0].caption.should.eql(payload.leadImage[0].caption)
+              results[0].leadImage[1]._id.should.eql(mediaObject2._id)
+              results[0].leadImage[1].fileName.should.eql('flowers.jpg')
+              results[0].leadImage[1].caption.should.eql(payload.leadImage[1].caption)
+              results[0]._composed.leadImage.should.eql([
+                mediaObject1._id,
+                mediaObject2._id
+              ])
 
               done(err)
             })
@@ -235,9 +659,162 @@ describe('Media field', () => {
         })
       })
     })
+  })
 
-    describe('PUT', () => {
-      it('should reject a string that isn\'t a hexadecimal ID', done => {
+  describe('PUT', () => {
+    describe('when `validation.mimeTypes` is defined', () => {
+      it('should reject a single value that does not correspond to a valid media object', done => {
+        client
+        .post('/media/upload')
+        .set('content-type', 'application/json')
+        .set('Authorization', `Bearer ${bearerToken}`)
+        .attach('avatar', 'test/acceptance/temp-workspace/media/flowers.jpg')
+        .end((err, res) => {
+          let mediaObject = res.body.results[0]
+          let payload = {
+            title: 'Media support in DADI API',
+            leadImageJPEG: mediaObject._id
+          }
+
+          client
+          .post('/vtest/testdb/test-schema')
+          .set('content-type', 'application/json')
+          .set('Authorization', `Bearer ${bearerToken}`)
+          .send(payload)
+          .end((err, res) => {
+            let {results} = res.body
+            let id = results[0]._id
+            let payload = {
+              leadImageJPEG: '5bf5369dd680048cf051bd92'
+            }
+
+            client
+            .put(`/vtest/testdb/test-schema/${id}`)
+            .set('content-type', 'application/json')
+            .set('Authorization', `Bearer ${bearerToken}`)
+            .expect(400)
+            .send(payload)
+            .end((err, res) => {
+              res.body.success.should.eql(false)
+              res.body.errors.length.should.eql(1)
+              res.body.errors[0].field.should.eql('leadImageJPEG')
+              res.body.errors[0].code.should.eql('ERROR_INVALID_ID')
+              res.body.errors[0].message.should.be.instanceOf(String)
+
+              done(err)
+            })
+          })
+        })
+      })
+
+      it('should reject a single value that corresponds to a media object with a MIME type that is not allowed', done => {
+        client
+        .post('/media/upload')
+        .set('content-type', 'application/json')
+        .set('Authorization', `Bearer ${bearerToken}`)
+        .attach('avatar', 'test/acceptance/temp-workspace/media/flowers.jpg')
+        .end((err, res) => {
+          let mediaObject = res.body.results[0]
+          let payload = {
+            title: 'Media support in DADI API',
+            leadImageJPEG: mediaObject._id
+          }
+
+          client
+          .post('/vtest/testdb/test-schema')
+          .set('content-type', 'application/json')
+          .set('Authorization', `Bearer ${bearerToken}`)
+          .send(payload)
+          .end((err, res) => {
+            let {results} = res.body
+            let id = results[0]._id
+
+            client
+            .post('/media/upload')
+            .set('content-type', 'application/json')
+            .set('Authorization', `Bearer ${bearerToken}`)
+            .attach('avatar', 'test/acceptance/temp-workspace/media/1f525.png')
+            .end((err, res) => {
+              let mediaObject = res.body.results[0]
+              let payload = {
+                leadImageJPEG: mediaObject._id
+              }
+
+              client
+              .put(`/vtest/testdb/test-schema/${id}`)
+              .set('content-type', 'application/json')
+              .set('Authorization', `Bearer ${bearerToken}`)
+              .expect(400)
+              .send(payload)
+              .end((err, res) => {
+                res.body.success.should.eql(false)
+                res.body.errors.length.should.eql(1)
+                res.body.errors[0].field.should.eql('leadImageJPEG')
+                res.body.errors[0].code.should.eql('ERROR_INVALID_MIME_TYPE')
+                res.body.errors[0].message.should.be.instanceOf(String)
+
+                done(err)
+              })
+            })
+          })
+        })
+      })
+
+      it('should accept a single value that corresponds to a media object with a MIME type that is allowed', done => {
+        client
+        .post('/media/upload')
+        .set('content-type', 'application/json')
+        .set('Authorization', `Bearer ${bearerToken}`)
+        .attach('avatar', 'test/acceptance/temp-workspace/media/flowers.jpg')
+        .end((err, res) => {
+          let mediaObject = res.body.results[0]
+          let payload1 = {
+            title: 'Media support in DADI API',
+            leadImageJPEG: mediaObject._id
+          }
+
+          client
+          .post('/vtest/testdb/test-schema')
+          .set('content-type', 'application/json')
+          .set('Authorization', `Bearer ${bearerToken}`)
+          .send(payload1)
+          .end((err, res) => {
+            let {results} = res.body
+            let id = results[0]._id
+
+            client
+            .post('/media/upload')
+            .set('content-type', 'application/json')
+            .set('Authorization', `Bearer ${bearerToken}`)
+            .attach('avatar', 'test/acceptance/temp-workspace/media/flowers.jpg')
+            .end((err, res) => {
+              let mediaObject = res.body.results[0]
+              let payload2 = {
+                leadImageJPEG: mediaObject._id
+              }
+
+              client
+              .put(`/vtest/testdb/test-schema/${id}`)
+              .set('content-type', 'application/json')
+              .set('Authorization', `Bearer ${bearerToken}`)
+              .expect(200)
+              .send(payload2)
+              .end((err, res) => {
+                res.body.results.should.be.instanceOf(Array)
+                res.body.results.length.should.eql(1)
+                res.body.results[0].title.should.eql(payload1.title)
+                res.body.results[0].leadImageJPEG._id.should.eql(mediaObject._id)
+                res.body.results[0].leadImageJPEG.fileName.should.eql('flowers.jpg')
+                res.body.results[0]._composed.leadImageJPEG.should.eql(mediaObject._id)
+
+                done(err)
+              })
+            })
+          })
+        })
+      })
+
+      it('should reject a multiple value where one of the IDs does not correspond to a valid media object', done => {
         client
         .post('/media/upload')
         .set('content-type', 'application/json')
@@ -247,7 +824,164 @@ describe('Media field', () => {
           let mediaObject = res.body.results[0]
           let payload = {
             title: 'Media support in DADI API',
-            leadImage: mediaObject._id
+            leadImageJPEG: [
+              '5bf5369dd680048cf051bd92',
+              mediaObject._id
+            ]
+          }
+
+          client
+          .post('/vtest/testdb/test-schema')
+          .set('content-type', 'application/json')
+          .set('Authorization', `Bearer ${bearerToken}`)
+          .expect(400)
+          .send(payload)
+          .end((err, res) => {
+            res.body.success.should.eql(false)
+            res.body.errors.length.should.eql(1)
+            res.body.errors[0].field.should.eql('leadImageJPEG')
+            res.body.errors[0].code.should.eql('ERROR_INVALID_ID')
+            res.body.errors[0].message.should.be.instanceOf(String)
+
+            done(err)
+          })
+        })
+      })
+
+      it('should reject a multiple value where one of the IDs corresponds to a media object with a MIME type that is not allowed', done => {
+        client
+        .post('/media/upload')
+        .set('content-type', 'application/json')
+        .set('Authorization', `Bearer ${bearerToken}`)
+        .attach('avatar', 'test/acceptance/temp-workspace/media/flowers.jpg')
+        .end((err, res) => {
+          let mediaObject = res.body.results[0]
+          let payload = {
+            title: 'Media support in DADI API',
+            leadImageJPEG: mediaObject._id
+          }
+
+          client
+          .post('/vtest/testdb/test-schema')
+          .set('content-type', 'application/json')
+          .set('Authorization', `Bearer ${bearerToken}`)
+          .send(payload)
+          .end((err, res) => {
+            let {results} = res.body
+            let id = results[0]._id
+
+            client
+            .post('/media/upload')
+            .set('content-type', 'application/json')
+            .set('Authorization', `Bearer ${bearerToken}`)
+            .attach('avatar', 'test/acceptance/temp-workspace/media/1f525.png')
+            .end((err, res) => {
+              let mediaObject1 = res.body.results[0]
+
+              client
+              .post('/media/upload')
+              .set('content-type', 'application/json')
+              .set('Authorization', `Bearer ${bearerToken}`)
+              .attach('avatar', 'test/acceptance/temp-workspace/media/flowers.jpg')
+              .end((err, res) => {
+                let mediaObject2 = res.body.results[0]
+                let payload = {
+                  title: 'Media support in DADI API',
+                  leadImageJPEG: [
+                    mediaObject1._id,
+                    mediaObject2._id
+                  ]
+                }
+
+                client
+                .put(`/vtest/testdb/test-schema/${id}`)
+                .set('content-type', 'application/json')
+                .set('Authorization', `Bearer ${bearerToken}`)
+                .expect(400)
+                .send(payload)
+                .end((err, res) => {
+                  res.body.success.should.eql(false)
+                  res.body.errors.length.should.eql(1)
+                  res.body.errors[0].field.should.eql('leadImageJPEG')
+                  res.body.errors[0].code.should.eql('ERROR_INVALID_MIME_TYPE')
+                  res.body.errors[0].message.should.be.instanceOf(String)
+
+                  done(err)
+                })
+              })
+            })
+          })
+        })
+      })
+    })
+
+    it('should reject a string that isn\'t a hexadecimal ID', done => {
+      client
+      .post('/media/upload')
+      .set('content-type', 'application/json')
+      .set('Authorization', `Bearer ${bearerToken}`)
+      .attach('avatar', 'test/acceptance/temp-workspace/media/1f525.png')
+      .end((err, res) => {
+        let mediaObject = res.body.results[0]
+        let payload = {
+          title: 'Media support in DADI API',
+          leadImage: mediaObject._id
+        }
+
+        client
+        .post('/vtest/testdb/test-schema')
+        .set('content-type', 'application/json')
+        .set('Authorization', `Bearer ${bearerToken}`)
+        .send(payload)
+        .end((err, res) => {
+          let {results} = res.body
+          
+          results.should.be.instanceOf(Array)
+          results.length.should.eql(1)
+          results[0].title.should.eql(payload.title)
+          results[0].leadImage._id.should.eql(mediaObject._id)
+          results[0].leadImage.fileName.should.eql('1f525.png')
+
+          let updatePayload = {
+            leadImage: 'QWERTYUIOP'
+          }
+
+          client
+          .put(`/vtest/testdb/test-schema/${results[0]._id}`)
+          .set('content-type', 'application/json')
+          .set('Authorization', `Bearer ${bearerToken}`)
+          .send(updatePayload)
+          .expect(400)
+          .end((err, res) => {
+            res.body.success.should.eql(false)
+            res.body.errors[0].field.should.eql('leadImage')
+            res.body.errors[0].code.should.eql('ERROR_VALUE_INVALID')
+
+            done(err)
+          })
+        })
+      })
+    })
+
+    it('should accept a media object ID as a string', done => {
+      client
+      .post('/media/upload')
+      .set('content-type', 'application/json')
+      .set('Authorization', `Bearer ${bearerToken}`)
+      .attach('avatar', 'test/acceptance/temp-workspace/media/1f525.png')
+      .end((err, res) => {
+        let mediaObject1 = res.body.results[0]
+
+        client
+        .post('/media/upload')
+        .set('content-type', 'application/json')
+        .set('Authorization', `Bearer ${bearerToken}`)
+        .attach('avatar', 'test/acceptance/temp-workspace/media/flowers.jpg')
+        .end((err, res) => {
+          let mediaObject2 = res.body.results[0]
+          let payload = {
+            title: 'Media support in DADI API',
+            leadImage: mediaObject1._id
           }
 
           client
@@ -261,11 +995,12 @@ describe('Media field', () => {
             results.should.be.instanceOf(Array)
             results.length.should.eql(1)
             results[0].title.should.eql(payload.title)
-            results[0].leadImage._id.should.eql(mediaObject._id)
+            results[0].leadImage._id.should.eql(mediaObject1._id)
             results[0].leadImage.fileName.should.eql('1f525.png')
+            results[0]._composed.leadImage.should.eql(mediaObject1._id)
 
             let updatePayload = {
-              leadImage: 'QWERTYUIOP'
+              leadImage: mediaObject2._id
             }
 
             client
@@ -273,95 +1008,98 @@ describe('Media field', () => {
             .set('content-type', 'application/json')
             .set('Authorization', `Bearer ${bearerToken}`)
             .send(updatePayload)
-            .expect(400)
             .end((err, res) => {
-              res.body.success.should.eql(false)
-              res.body.errors[0].field.should.eql('leadImage')
-              res.body.errors[0].code.should.eql('ERROR_VALUE_INVALID')
-
-              done(err)
-            })
-          })
-        })
-      })
-
-      it('should accept a media object ID as a string', done => {
-        client
-        .post('/media/upload')
-        .set('content-type', 'application/json')
-        .set('Authorization', `Bearer ${bearerToken}`)
-        .attach('avatar', 'test/acceptance/temp-workspace/media/1f525.png')
-        .end((err, res) => {
-          let mediaObject1 = res.body.results[0]
-
-          client
-          .post('/media/upload')
-          .set('content-type', 'application/json')
-          .set('Authorization', `Bearer ${bearerToken}`)
-          .attach('avatar', 'test/acceptance/temp-workspace/media/flowers.jpg')
-          .end((err, res) => {
-            let mediaObject2 = res.body.results[0]
-            let payload = {
-              title: 'Media support in DADI API',
-              leadImage: mediaObject1._id
-            }
-
-            client
-            .post('/vtest/testdb/test-schema')
-            .set('content-type', 'application/json')
-            .set('Authorization', `Bearer ${bearerToken}`)
-            .send(payload)
-            .end((err, res) => {
-              let {results} = res.body
-              
-              results.should.be.instanceOf(Array)
-              results.length.should.eql(1)
-              results[0].title.should.eql(payload.title)
-              results[0].leadImage._id.should.eql(mediaObject1._id)
-              results[0].leadImage.fileName.should.eql('1f525.png')
-
-              let updatePayload = {
-                leadImage: mediaObject2._id
-              }
-
               client
-              .put(`/vtest/testdb/test-schema/${results[0]._id}`)
+              .get(`/vtest/testdb/test-schema/${results[0]._id}`)
               .set('content-type', 'application/json')
               .set('Authorization', `Bearer ${bearerToken}`)
-              .send(updatePayload)
               .end((err, res) => {
-                client
-                .get(`/vtest/testdb/test-schema/${results[0]._id}`)
-                .set('content-type', 'application/json')
-                .set('Authorization', `Bearer ${bearerToken}`)
-                .end((err, res) => {
-                  let {results} = res.body
+                let {results} = res.body
 
-                  results.should.be.instanceOf(Array)
-                  results.length.should.eql(1)
-                  results[0].title.should.eql(payload.title)
-                  results[0].leadImage._id.should.eql(mediaObject2._id)
-                  results[0].leadImage.fileName.should.eql('flowers.jpg')
+                results.should.be.instanceOf(Array)
+                results.length.should.eql(1)
+                results[0].title.should.eql(payload.title)
+                results[0].leadImage._id.should.eql(mediaObject2._id)
+                results[0].leadImage.fileName.should.eql('flowers.jpg')
+                results[0]._composed.leadImage.should.eql(mediaObject2._id)
 
-                  done(err)
-                })
+                done(err)
               })
             })
           })
         })
       })
+    })
 
-      it('should reject an object that doesn\'t contain a hexadecimal ID', done => {
+    it('should reject an object that doesn\'t contain a hexadecimal ID', done => {
+      client
+      .post('/media/upload')
+      .set('content-type', 'application/json')
+      .set('Authorization', `Bearer ${bearerToken}`)
+      .attach('avatar', 'test/acceptance/temp-workspace/media/1f525.png')
+      .end((err, res) => {
+        let mediaObject = res.body.results[0]
+        let payload = {
+          title: 'Media support in DADI API',
+          leadImage: mediaObject._id
+        }
+
+        client
+        .post('/vtest/testdb/test-schema')
+        .set('content-type', 'application/json')
+        .set('Authorization', `Bearer ${bearerToken}`)
+        .send(payload)
+        .end((err, res) => {
+          let {results} = res.body
+          
+          results.should.be.instanceOf(Array)
+          results.length.should.eql(1)
+          results[0].title.should.eql(payload.title)
+          results[0].leadImage._id.should.eql(mediaObject._id)
+          results[0].leadImage.fileName.should.eql('1f525.png')
+
+          let updatePayload = {
+            leadImage: {
+              _id: 'QWERTYUIOP'
+            }
+          }
+
+          client
+          .put(`/vtest/testdb/test-schema/${results[0]._id}`)
+          .set('content-type', 'application/json')
+          .set('Authorization', `Bearer ${bearerToken}`)
+          .send(updatePayload)
+          .expect(400)
+          .end((err, res) => {
+            res.body.success.should.eql(false)
+            res.body.errors[0].field.should.eql('leadImage')
+            res.body.errors[0].code.should.eql('ERROR_VALUE_INVALID')
+
+            done(err)
+          })
+        })
+      })
+    })
+
+    it('should accept a media object ID as an object', done => {
+      client
+      .post('/media/upload')
+      .set('content-type', 'application/json')
+      .set('Authorization', `Bearer ${bearerToken}`)
+      .attach('avatar', 'test/acceptance/temp-workspace/media/1f525.png')
+      .end((err, res) => {
+        let mediaObject1 = res.body.results[0]
+
         client
         .post('/media/upload')
         .set('content-type', 'application/json')
         .set('Authorization', `Bearer ${bearerToken}`)
-        .attach('avatar', 'test/acceptance/temp-workspace/media/1f525.png')
+        .attach('avatar', 'test/acceptance/temp-workspace/media/flowers.jpg')
         .end((err, res) => {
-          let mediaObject = res.body.results[0]
+          let mediaObject2 = res.body.results[0]
           let payload = {
             title: 'Media support in DADI API',
-            leadImage: mediaObject._id
+            leadImage: mediaObject1._id
           }
 
           client
@@ -375,12 +1113,13 @@ describe('Media field', () => {
             results.should.be.instanceOf(Array)
             results.length.should.eql(1)
             results[0].title.should.eql(payload.title)
-            results[0].leadImage._id.should.eql(mediaObject._id)
+            results[0].leadImage._id.should.eql(mediaObject1._id)
             results[0].leadImage.fileName.should.eql('1f525.png')
+            results[0]._composed.leadImage.should.eql(mediaObject1._id)
 
             let updatePayload = {
               leadImage: {
-                _id: 'QWERTYUIOP'
+                _id: mediaObject2._id
               }
             }
 
@@ -389,159 +1128,103 @@ describe('Media field', () => {
             .set('content-type', 'application/json')
             .set('Authorization', `Bearer ${bearerToken}`)
             .send(updatePayload)
-            .expect(400)
             .end((err, res) => {
-              res.body.success.should.eql(false)
-              res.body.errors[0].field.should.eql('leadImage')
-              res.body.errors[0].code.should.eql('ERROR_VALUE_INVALID')
-
-              done(err)
-            })
-          })
-        })
-      })
-
-      it('should accept a media object ID as an object', done => {
-        client
-        .post('/media/upload')
-        .set('content-type', 'application/json')
-        .set('Authorization', `Bearer ${bearerToken}`)
-        .attach('avatar', 'test/acceptance/temp-workspace/media/1f525.png')
-        .end((err, res) => {
-          let mediaObject1 = res.body.results[0]
-
-          client
-          .post('/media/upload')
-          .set('content-type', 'application/json')
-          .set('Authorization', `Bearer ${bearerToken}`)
-          .attach('avatar', 'test/acceptance/temp-workspace/media/flowers.jpg')
-          .end((err, res) => {
-            let mediaObject2 = res.body.results[0]
-            let payload = {
-              title: 'Media support in DADI API',
-              leadImage: mediaObject1._id
-            }
-
-            client
-            .post('/vtest/testdb/test-schema')
-            .set('content-type', 'application/json')
-            .set('Authorization', `Bearer ${bearerToken}`)
-            .send(payload)
-            .end((err, res) => {
-              let {results} = res.body
-              
-              results.should.be.instanceOf(Array)
-              results.length.should.eql(1)
-              results[0].title.should.eql(payload.title)
-              results[0].leadImage._id.should.eql(mediaObject1._id)
-              results[0].leadImage.fileName.should.eql('1f525.png')
-
-              let updatePayload = {
-                leadImage: {
-                  _id: mediaObject2._id
-                }
-              }
-
               client
-              .put(`/vtest/testdb/test-schema/${results[0]._id}`)
+              .get(`/vtest/testdb/test-schema/${results[0]._id}`)
               .set('content-type', 'application/json')
               .set('Authorization', `Bearer ${bearerToken}`)
-              .send(updatePayload)
               .end((err, res) => {
-                client
-                .get(`/vtest/testdb/test-schema/${results[0]._id}`)
-                .set('content-type', 'application/json')
-                .set('Authorization', `Bearer ${bearerToken}`)
-                .end((err, res) => {
-                  let {results} = res.body
+                let {results} = res.body
 
-                  results.should.be.instanceOf(Array)
-                  results.length.should.eql(1)
-                  results[0].title.should.eql(payload.title)
-                  results[0].leadImage._id.should.eql(mediaObject2._id)
-                  results[0].leadImage.fileName.should.eql('flowers.jpg')
+                results.should.be.instanceOf(Array)
+                results.length.should.eql(1)
+                results[0].title.should.eql(payload.title)
+                results[0].leadImage._id.should.eql(mediaObject2._id)
+                results[0].leadImage.fileName.should.eql('flowers.jpg')
+                results[0]._composed.leadImage.should.eql(mediaObject2._id)
 
-                  done(err)
-                })
+                done(err)
               })
             })
           })
         })
       })
+    })
 
-      it('should accept a media object ID as an object with additional metadata', done => {
+    it('should accept a media object ID as an object with additional metadata', done => {
+      client
+      .post('/media/upload')
+      .set('content-type', 'application/json')
+      .set('Authorization', `Bearer ${bearerToken}`)
+      .attach('avatar', 'test/acceptance/temp-workspace/media/1f525.png')
+      .end((err, res) => {
+        let mediaObject1 = res.body.results[0]
+
         client
         .post('/media/upload')
         .set('content-type', 'application/json')
         .set('Authorization', `Bearer ${bearerToken}`)
-        .attach('avatar', 'test/acceptance/temp-workspace/media/1f525.png')
+        .attach('avatar', 'test/acceptance/temp-workspace/media/flowers.jpg')
         .end((err, res) => {
-          let mediaObject1 = res.body.results[0]
+          let mediaObject2 = res.body.results[0]
+          let payload = {
+            title: 'Media support in DADI API',
+            leadImage: {
+              _id: mediaObject1._id,
+              altText: 'Original alt text',
+              caption: 'Original caption'
+            }
+          }
 
           client
-          .post('/media/upload')
+          .post('/vtest/testdb/test-schema')
           .set('content-type', 'application/json')
           .set('Authorization', `Bearer ${bearerToken}`)
-          .attach('avatar', 'test/acceptance/temp-workspace/media/flowers.jpg')
+          .send(payload)
           .end((err, res) => {
-            let mediaObject2 = res.body.results[0]
-            let payload = {
-              title: 'Media support in DADI API',
+            let {results} = res.body
+            
+            results.should.be.instanceOf(Array)
+            results.length.should.eql(1)
+            results[0].title.should.eql(payload.title)
+            results[0].leadImage._id.should.eql(mediaObject1._id)
+            results[0].leadImage.altText.should.eql(payload.leadImage.altText)
+            results[0].leadImage.caption.should.eql(payload.leadImage.caption)
+            results[0].leadImage.fileName.should.eql('1f525.png')
+            results[0]._composed.leadImage.should.eql(mediaObject1._id)
+
+            let updatePayload = {
               leadImage: {
-                _id: mediaObject1._id,
-                altText: 'Original alt text',
-                caption: 'Original caption'
+                _id: mediaObject2._id,
+                altText: 'New alt text',
+                crop: [16, 32, 64, 128]
               }
             }
 
             client
-            .post('/vtest/testdb/test-schema')
+            .put(`/vtest/testdb/test-schema/${results[0]._id}`)
             .set('content-type', 'application/json')
             .set('Authorization', `Bearer ${bearerToken}`)
-            .send(payload)
+            .send(updatePayload)
             .end((err, res) => {
-              let {results} = res.body
-              
-              results.should.be.instanceOf(Array)
-              results.length.should.eql(1)
-              results[0].title.should.eql(payload.title)
-              results[0].leadImage._id.should.eql(mediaObject1._id)
-              results[0].leadImage.altText.should.eql(payload.leadImage.altText)
-              results[0].leadImage.caption.should.eql(payload.leadImage.caption)
-              results[0].leadImage.fileName.should.eql('1f525.png')
-
-              let updatePayload = {
-                leadImage: {
-                  _id: mediaObject2._id,
-                  altText: 'New alt text',
-                  crop: [16, 32, 64, 128]
-                }
-              }
-
               client
-              .put(`/vtest/testdb/test-schema/${results[0]._id}`)
+              .get(`/vtest/testdb/test-schema/${results[0]._id}`)
               .set('content-type', 'application/json')
               .set('Authorization', `Bearer ${bearerToken}`)
-              .send(updatePayload)
               .end((err, res) => {
-                client
-                .get(`/vtest/testdb/test-schema/${results[0]._id}`)
-                .set('content-type', 'application/json')
-                .set('Authorization', `Bearer ${bearerToken}`)
-                .end((err, res) => {
-                  let {results} = res.body
+                let {results} = res.body
 
-                  results.should.be.instanceOf(Array)
-                  results.length.should.eql(1)
-                  results[0].title.should.eql(payload.title)
-                  results[0].leadImage._id.should.eql(mediaObject2._id)
-                  results[0].leadImage.altText.should.eql(updatePayload.leadImage.altText)
-                  results[0].leadImage.crop.should.eql(updatePayload.leadImage.crop)
-                  should.not.exist(results[0].leadImage.caption)
-                  results[0].leadImage.fileName.should.eql('flowers.jpg')
+                results.should.be.instanceOf(Array)
+                results.length.should.eql(1)
+                results[0].title.should.eql(payload.title)
+                results[0].leadImage._id.should.eql(mediaObject2._id)
+                results[0].leadImage.altText.should.eql(updatePayload.leadImage.altText)
+                results[0].leadImage.crop.should.eql(updatePayload.leadImage.crop)
+                should.not.exist(results[0].leadImage.caption)
+                results[0].leadImage.fileName.should.eql('flowers.jpg')
+                results[0]._composed.leadImage.should.eql(mediaObject2._id)
 
-                  done(err)
-                })
+                done(err)
               })
             })
           })

--- a/test/acceptance/workspace/collections/vtest/testdb/collection.test-schema.json
+++ b/test/acceptance/workspace/collections/vtest/testdb/collection.test-schema.json
@@ -19,7 +19,13 @@
     },
     "leadImage": {
       "type": "Media"
-    }    
+    },
+    "leadImageJPEG": {
+      "type": "Media",
+      "validation": {
+        "mimeTypes": ["image/jpeg"]
+      }
+    }
   },
   "settings": {
     "cache": true,


### PR DESCRIPTION
This PR adds two things to the new Media field type:

- A `mimeTypes` validation operator
- A `_composed` field indicating which (if any) of the IDs have been composed in the response, consistent with the behaviour observed in Reference fields.

Closes #513 