### PR TITLE
Make secret hashing configurable

### DIFF
--- a/config.js
+++ b/config.js
@@ -132,6 +132,11 @@ var conf = convict({
       default: 'test',
       env: 'DB_AUTH_NAME'
     },
+    hashSecrets: {
+      doc: 'Whether to hash client secrets',
+      format: Boolean,
+      default: false
+    },
     saltRounds: {
       doc: 'The number of rounds to go through when hashing a password',
       format: Number,

--- a/test/acceptance/acl/clients-api/post.js
+++ b/test/acceptance/acl/clients-api/post.js
@@ -524,76 +524,80 @@ module.exports = () => {
   })
 
   describe('success states (the client has "create" access to the "clients" resource)', () => {
-    it('should hash client secrets and salt them using the number of rounds specified in the `auth.saltRounds` config property', done => {
-      config.set('auth.saltRounds', 5)
-  
-      const spy = sinon.spy(bcrypt, 'hash')
-      const testClient = {
-        clientId: 'apiClient',
-        secret: 'someSecret',
-        resources: {
-          clients: {
-            create: true
+    describe('if `auth.hashSecrets` is set to true', () => {
+      it('should hash client secrets and salt them using the number of rounds specified in the `auth.saltRounds` config property', done => {
+        config.set('auth.hashSecrets', true)
+        config.set('auth.saltRounds', 5)
+    
+        const spy = sinon.spy(bcrypt, 'hash')
+        const testClient = {
+          clientId: 'apiClient',
+          secret: 'someSecret',
+          resources: {
+            clients: {
+              create: true
+            }
           }
         }
-      }
-      const newClient1 = {
-        clientId: 'newClient1',
-        secret: 'aNewSecret1'
-      }
-      const newClient2 = {
-        clientId: 'newClient2',
-        secret: 'aNewSecret2'
-      }
-
-      help.createACLClient(testClient).then(() => {
-        client
-        .post(config.get('auth.tokenUrl'))
-        .set('content-type', 'application/json')
-        .send({
-          clientId: testClient.clientId,
-          secret: testClient.secret
-        })
-        .expect(200)
-        .expect('content-type', 'application/json')
-        .end((err, res) => {
-          if (err) return done(err)
-
-          const {accessToken} = res.body
-
+        const newClient1 = {
+          clientId: 'newClient1',
+          secret: 'aNewSecret1'
+        }
+        const newClient2 = {
+          clientId: 'newClient2',
+          secret: 'aNewSecret2'
+        }
+  
+        help.createACLClient(testClient).then(() => {
           client
-          .post('/api/clients')
-          .send(newClient1)
+          .post(config.get('auth.tokenUrl'))
           .set('content-type', 'application/json')
-          .set('Authorization', `Bearer ${accessToken}`)
+          .send({
+            clientId: testClient.clientId,
+            secret: testClient.secret
+          })
+          .expect(200)
           .expect('content-type', 'application/json')
           .end((err, res) => {
-            res.statusCode.should.eql(201)
-
-            spy.getCall(0).args[0].should.eql('aNewSecret1')
-            spy.getCall(0).args[1].should.eql(5)
-
-            config.set('auth.saltRounds', 8)
-
+            if (err) return done(err)
+  
+            const {accessToken} = res.body
+  
             client
             .post('/api/clients')
-            .send(newClient2)
+            .send(newClient1)
             .set('content-type', 'application/json')
             .set('Authorization', `Bearer ${accessToken}`)
             .expect('content-type', 'application/json')
             .end((err, res) => {
               res.statusCode.should.eql(201)
   
-              config.set('auth.saltRounds', configBackup.auth.saltRounds)
-
-              spy.getCall(1).args[0].should.eql('aNewSecret2')
-              spy.getCall(1).args[1].should.eql(8)
+              spy.getCall(0).args[0].should.eql('aNewSecret1')
+              spy.getCall(0).args[1].should.eql(5)
   
-              spy.restore()
+              config.set('auth.saltRounds', 8)
   
-              done(err)
-            })
-          })          
+              client
+              .post('/api/clients')
+              .send(newClient2)
+              .set('content-type', 'application/json')
+              .set('Authorization', `Bearer ${accessToken}`)
+              .expect('content-type', 'application/json')
+              .end((err, res) => {
+                res.statusCode.should.eql(201)
+    
+                config.set('auth.hashSecrets', configBackup.auth.hashSecrets)
+                config.set('auth.saltRounds', configBackup.auth.saltRounds)
+  
+                spy.getCall(1).args[0].should.eql('aNewSecret2')
+                spy.getCall(1).args[1].should.eql(8)
+    
+                spy.restore()
+    
+                done(err)
+              })
+            })          
+          })
         })
       })
     })

--- a/test/acceptance/help.js
+++ b/test/acceptance/help.js
@@ -8,15 +8,18 @@ const config = require(__dirname + '/../../config')
 const request = require('supertest')
 
 function hashClientSecret(client) {
+  if (client._hashVersion === undefined && config.get('auth.hashSecrets')) {
+    client._hashVersion = 1
+  }
+
   switch (client._hashVersion) {
-    case undefined:
     case 1:
       return Object.assign({}, client, {
         _hashVersion: 1,
         secret: bcrypt.hashSync(client.secret, config.get('auth.saltRounds'))
       })
 
-    case null:
+    default:
       delete client._hashVersion
 
       return client


### PR DESCRIPTION
... and disabled by default.

Can be enabled by setting `auth.hashSecrets` to `true`.