### PR TITLE
Add Etag header to response

### DIFF
--- a/dadi/lib/index.js
+++ b/dadi/lib/index.js
@@ -6,7 +6,7 @@ var chokidar = require('chokidar')
 var cluster = require('cluster')
 var colors = require('colors') // eslint-disable-line
 var debug = require('debug')('api:server')
-var parsecomments = require('parse-comments')
+var ParseComments = require('parse-comments')
 var fs = require('fs')
 var mkdirp = require('mkdirp')
 var path = require('path')
@@ -632,7 +632,7 @@ Server.prototype.addEndpointResource = function (options) {
 
       this.addComponent({
         aclKey,
-        docs: parsecomments(content),
+        docs: new ParseComments().parse(content),
         component,
         filepath,
         route
@@ -688,7 +688,7 @@ Server.prototype.addHook = function (options) {
     var opts = {
       route: 'hook:' + name,
       component: filepath,
-      docs: parsecomments(content),
+      docs: new ParseComments().parse(content),
       filepath: filepath
     }
 

--- a/package.json
+++ b/package.json
@@ -42,6 +42,7 @@
     "debug": "3.1.0",
     "deep-clone": "^3.0.2",
     "deepmerge": "^2.1.0",
+    "etag": "^1.8.1",
     "fs-extra": "^3.0.1",
     "imagesize": "^1.0.0",
     "js-promise-queue": "^1.1.0",
@@ -52,7 +53,7 @@
     "moment": "2.19.3",
     "natural": "^0.6.1",
     "object-path": "^0.11.4",
-    "parse-comments": "0.4.3",
+    "parse-comments": "^1.0.0",
     "path-to-regexp": "~1.7.0",
     "recovery": "^0.2.6",
     "require-directory": "^2.1.1",
@@ -65,7 +66,7 @@
     "vary": "^1.1.2"
   },
   "devDependencies": {
-    "@commitlint/cli": "~4.1.1",
+    "@commitlint/cli": "^7.5.2",
     "@commitlint/config-angular": "~3.1.1",
     "aws-sdk-mock": "1.6.1",
     "coveralls": "^3.0.1",
@@ -83,7 +84,7 @@
     "should": "4.0.4",
     "sinon": "2.3.2",
     "snazzy": "7.0.0",
-    "snyk": "^1.104.1",
+    "snyk": "^1.147.3",
     "standard": "8.6.0",
     "supertest": "^3.1.0",
     "uuid": "^3.3.2"

--- a/test/acceptance/app.js
+++ b/test/acceptance/app.js
@@ -402,7 +402,7 @@ describe('Application', function () {
             docs.should.exist
             docs.should.be.Array
 
-            docs[0].lead.should.eql('Adds two numbers together.')
+            docs[0].description.should.eql('Adds two numbers together.')
 
             done()
           })

--- a/test/acceptance/rest-endpoints/collections-api/get.js
+++ b/test/acceptance/rest-endpoints/collections-api/get.js
@@ -1229,5 +1229,32 @@ describe('Collections API – GET', function () {
         })
       })
     })
+
+    it('should respond with 304 if etag matches If-None-Match header', function (done) {
+      help.createDoc(bearerToken, function (err, doc1) {
+        if (err) return done(err)
+        help.createDoc(bearerToken, function (err, doc2) {
+          if (err) return done(err)
+
+          var client = request(connectionString)
+          client
+            .get('/vtest/testdb/test-schema')
+            .set('Authorization', 'Bearer ' + bearerToken)
+            .expect(200)
+            .expect('content-type', 'application/json')
+            .end((err, res) => {
+              if (err) return done(err)
+
+              let etag = res.headers['etag']
+
+              client
+                .get('/vtest/testdb/test-schema')
+                .set('Authorization', 'Bearer ' + bearerToken)
+                .set('If-None-Match', etag)
+                .expect(304, done)
+            })
+        })
+      })
+    })
   })
 })

--- a/test/unit/helpTest.js
+++ b/test/unit/helpTest.js
@@ -44,7 +44,7 @@ describe('Help', function (done) {
     it('should send an error with the formatted message corresponding to the API error code with the status code provided', done => {
       let res = {
         end: function end (resBody) {
-          this.setHeader.callCount.should.eql(2)
+          this.setHeader.callCount.should.eql(3)
           this.setHeader.args[0][0].should.eql('Content-Length')
           this.setHeader.args[0][1].should.be.Number
           this.setHeader.args[1][0].should.eql('Content-Type')
@@ -68,7 +68,7 @@ describe('Help', function (done) {
     it('should send an error with the formatted message corresponding to the API error code with the status code 500 if one is not provided', done => {
       let res = {
         end: function end (resBody) {
-          this.setHeader.callCount.should.eql(2)
+          this.setHeader.callCount.should.eql(3)
           this.setHeader.args[0][0].should.eql('Content-Length')
           this.setHeader.args[0][1].should.be.Number
           this.setHeader.args[1][0].should.eql('Content-Type')


### PR DESCRIPTION
Close #546 

This PR adds an ETag header to all GET responses, and returns a 304 if the hash of a response matches a request's If-None-Match header.

It also upgrades the ParseComments library to remove a vulnerability.