### PR TITLE
Add default for index keys

### DIFF
--- a/dadi/lib/model/index.js
+++ b/dadi/lib/model/index.js
@@ -81,7 +81,7 @@ const Model = function (name, schema, connection, settings) {
   if (this.settings.index && !Array.isArray(this.settings.index)) {
     this.settings.index = [
       {
-        keys: this.settings.index.keys,
+        keys: this.settings.index.keys || {},
         options: this.settings.index.options || {}
       }
     ]


### PR DESCRIPTION
Note: this fixes an issue when using the MongoDB adapter but is relevant for all adapters.

If a collection's index block has been structured incorrectly and doesn't include a `keys` property, index creation fails and in some cases API will not boot, as the database adapter is expecting to iterate over the `keys` property.

An example of an incorrect index setting for a collection:

```
"index": {
  "enabled": true
}
```