### PR TITLE
Add new collection endpoints + new properties in versions endpoint

### DIFF
--- a/dadi/lib/controller/collections.js
+++ b/dadi/lib/controller/collections.js
@@ -3,19 +3,70 @@ const config = require('../../../config')
 const help = require('../help')
 const modelStore = require('../model/')
 const schemaStore = require('../model/schemaStore')
+const url = require('url')
 
 const Collections = function(server) {
   server.app.routeMethods('/api/collections', {
-    get: this.get.bind(this),
+    get: this.getAll.bind(this),
     post: this.post.bind(this)
   })
 
-  server.app.routeMethods('/api/collections/:collection*', {
+  server.app.routeMethods('/api/collections/:property/:collection', {
     delete: this.delete.bind(this),
-    put: this.put.bind(this)
+    get: this.getCollection.bind(this)
+  })
+
+  server.app.routeMethods('/api/collections/:property/:collection/fields', {
+    post: this.updateField.bind(this)
+  })
+
+  server.app.routeMethods(
+    '/api/collections/:property/:collection/fields/:field',
+    {
+      delete: this.updateField.bind(this),
+      put: this.updateField.bind(this)
+    }
+  )
+
+  server.app.routeMethods('/api/collections/:property/:collection/settings', {
+    put: this.putSettings.bind(this)
   })
 
   this.server = server
+}
+
+Collections.prototype._getFieldsProjection = function(req) {
+  try {
+    const {query} = url.parse(req.url, true)
+    const fields = query.fields && JSON.parse(query.fields)
+    const hasFieldProjection =
+      typeof fields === 'object' &&
+      Object.keys(fields).every((fieldName, index) => {
+        if (fields[fieldName] !== 0 && fields[fieldName] !== 1) {
+          return false
+        }
+
+        const nextFieldName = Object.keys(fields)[index + 1]
+
+        if (
+          nextFieldName !== undefined &&
+          fields[fieldName] !== fields[nextFieldName]
+        ) {
+          return false
+        }
+
+        return true
+      })
+
+    if (hasFieldProjection) {
+      return {
+        fields: Object.keys(fields),
+        type: fields[Object.keys(fields)[0]]
+      }
+    }
+  } catch (_) {
+    // no-op
+  }
 }
 
 Collections.prototype.delete = async function(req, res, next) {
@@ -25,7 +76,7 @@ Collections.prototype.delete = async function(req, res, next) {
     )
   }
 
-  const [property, collection] = (req.params.collection || '').split('/')
+  const {collection, property} = req.params
 
   if (!property || !collection) {
     return this.handleError(new Error('SCHEMA_NOT_FOUND'), res, next)
@@ -60,12 +111,14 @@ Collections.prototype.delete = async function(req, res, next) {
   }
 }
 
-Collections.prototype.get = async function(req, res, next) {
+Collections.prototype.getAll = async function(req, res, next) {
   if (!req.dadiApiClient.clientId) {
     return help.sendBackJSON(null, res, next)(
       acl.createError(req.dadiApiClient)
     )
   }
+
+  const fieldsProjection = this._getFieldsProjection(req)
 
   try {
     const clientIsAdmin = acl.client.isAdmin(req.dadiApiClient)
@@ -85,11 +138,11 @@ Collections.prototype.get = async function(req, res, next) {
       .map(key => {
         const model = models[key]
         const data = {
+          fields: model.schema,
           property: model.property,
           name: (model.settings && model.settings.displayName) || model.name,
           slug: model.name,
           path: `/${model.property}/${model.name}`,
-          fields: model.schema,
           settings: Object.assign({}, model.settings, {
             database: undefined
           })
@@ -103,6 +156,21 @@ Collections.prototype.get = async function(req, res, next) {
           if (model.settings.type) {
             data.type = model.settings.type
           }
+        }
+
+        if (fieldsProjection) {
+          const {fields, type} = fieldsProjection
+
+          return Object.keys(data).reduce((result, fieldName) => {
+            if (
+              (type === 1 && fields.includes(fieldName)) ||
+              (type === 0 && !fields.includes(fieldName))
+            ) {
+              result[fieldName] = data[fieldName]
+            }
+
+            return result
+          }, {})
         }
 
         return data
@@ -150,12 +218,106 @@ Collections.prototype.get = async function(req, res, next) {
   }
 }
 
+Collections.prototype.getCollection = async function(req, res, next) {
+  if (!req.dadiApiClient.clientId) {
+    return help.sendBackJSON(null, res, next)(
+      acl.createError(req.dadiApiClient)
+    )
+  }
+
+  try {
+    const fieldsProjection = this._getFieldsProjection(req)
+    const {collection, property} = req.params
+    const clientIsAdmin = acl.client.isAdmin(req.dadiApiClient)
+    const access = await (clientIsAdmin
+      ? {}
+      : acl.access.get(req.dadiApiClient))
+    const model = modelStore.get({
+      name: collection,
+      property
+    })
+
+    if (!model || !model.isListable) {
+      return this.handleError(new Error('SCHEMA_NOT_FOUND'), res, next)
+    }
+
+    const {aclKey} = model
+    const hasReadAccess = access[aclKey] && access[aclKey].read
+
+    if (!clientIsAdmin && !hasReadAccess) {
+      return this.handleError(new Error('SCHEMA_NOT_FOUND'), res, next)
+    }
+
+    const data = {
+      property: model.property,
+      name: (model.settings && model.settings.displayName) || model.name,
+      slug: model.name,
+      path: `/${model.property}/${model.name}`,
+      fields: model.schema,
+      settings: Object.assign({}, model.settings, {
+        database: undefined
+      })
+    }
+
+    if (model.settings) {
+      if (model.settings.lastModifiedAt) {
+        data.lastModifiedAt = model.settings.lastModifiedAt
+      }
+
+      if (model.settings.type) {
+        data.type = model.settings.type
+      }
+    }
+
+    const formattedData = fieldsProjection
+      ? Object.keys(data).reduce((result, fieldName) => {
+          const {fields, type} = fieldsProjection
+
+          if (
+            (type === 1 && fields.includes(fieldName)) ||
+            (type === 0 && !fields.includes(fieldName))
+          ) {
+            result[fieldName] = data[fieldName]
+          }
+
+          return result
+        }, {})
+      : data
+
+    return help.sendBackJSON(200, res, next)(null, formattedData)
+  } catch (error) {
+    return this.handleError(error, res, next)
+  }
+}
+
 Collections.prototype.handleError = function(error, res, next) {
   switch (error.message) {
+    case 'FIELD_ALREADY_EXISTS':
+      return help.sendBackJSON(419, res, next)(null, {
+        success: false,
+        errors: [
+          {
+            code: 'ERROR_FIELD_EXISTS',
+            field: error.field,
+            message: 'already exists in the collection'
+          }
+        ]
+      })
+
+    case 'FIELD_NOT_FOUND':
+      return help.sendBackJSON(404, res, next)(null, {
+        success: false
+      })
+
     case 'SCHEMA_EXISTS':
       return help.sendBackJSON(409, res, next)(null, {
         success: false,
-        errors: ['The collection already exists']
+        errors: [
+          {
+            code: 'ERROR_COLLECTION_EXISTS',
+            message: 'The collection already exists'
+          }
+        ]
       })
 
     case 'SCHEMA_NOT_FOUND':
@@ -181,7 +343,7 @@ Collections.prototype.post = async function(req, res, next) {
     )
   }
 
-  const {fields, name, property, settings} = req.body
+  const {fields = null, name, property, settings} = req.body
 
   try {
     const clientIsAdmin = acl.client.isAdmin(req.dadiApiClient)
@@ -212,20 +374,18 @@ Collections.prototype.post = async function(req, res, next) {
   }
 }
 
-Collections.prototype.put = async function(req, res, next) {
+Collections.prototype.putSettings = async function(req, res, next) {
   if (!req.dadiApiClient.clientId) {
     return help.sendBackJSON(null, res, next)(
       acl.createError(req.dadiApiClient)
     )
   }
 
-  const [property, collection] = (req.params.collection || '').split('/')
+  const {collection, property} = req.params
 
   if (!property || !collection) {
     return this.handleError(new Error('SCHEMA_NOT_FOUND'), res, next)
   }
-
-  const {fields, settings} = req.body
 
   try {
     const clientIsAdmin = acl.client.isAdmin(req.dadiApiClient)
@@ -241,20 +401,97 @@ Collections.prototype.put = async function(req, res, next) {
       )
     }
 
-    const newSchema = await schemaStore.update({
-      fields,
+    const newSchema = await schemaStore.updateSettings({
       name: collection,
       property,
-      settings
+      settings: req.body
     })
 
-    if (newSchema === null) {
-      return this.handleError(new Error('SCHEMA_NOT_FOUND'), res, next)
+    return help.sendBackJSON(200, res, next)(
+      null,
+      schemaStore.formatForOutput(newSchema)
+    )
+  } catch (error) {
+    return this.handleError(error, res, next)
+  }
+}
+
+Collections.prototype.updateField = async function(req, res, next) {
+  if (!req.dadiApiClient.clientId) {
+    return help.sendBackJSON(null, res, next)(
+      acl.createError(req.dadiApiClient)
+    )
+  }
+
+  const {method, params} = req
+  const {collection, field, property} = params
+
+  if (!property || !collection) {
+    return this.handleError(new Error('SCHEMA_NOT_FOUND'), res, next)
+  }
+
+  try {
+    const clientIsAdmin = acl.client.isAdmin(req.dadiApiClient)
+    const access = await (clientIsAdmin
+      ? {}
+      : acl.access.get(req.dadiApiClient, 'collections'))
+
+    // To update a collection, the client needs to be an admin or have `update`
+    // access to the `collections` resource.
+    if (!clientIsAdmin && !access.update) {
+      return help.sendBackJSON(null, res, next)(
+        acl.createError(req.dadiApiClient)
+      )
     }
 
-    return help.sendBackJSON(200, res, next)(null, {
-      results: [schemaStore.formatForOutput(newSchema)]
-    })
+    let newSchema = null
+
+    switch (method) {
+      case 'DELETE': {
+        newSchema = await schemaStore.deleteFields({
+          fields: [field],
+          name: collection,
+          property
+        })
+
+        break
+      }
+
+      case 'POST': {
+        const {name} = req.body
+        const schema = Object.assign({}, req.body)
+
+        // We don't want the `name` property in the field's schema.
+        delete schema.name
+
+        newSchema = await schemaStore.addFields({
+          fields: {
+            [name]: schema
+          },
+          name: collection,
+          property
+        })
+
+        break
+      }
+
+      case 'PUT': {
+        newSchema = await schemaStore.updateFields({
+          fields: {
+            [field]: req.body
+          },
+          name: collection,
+          property
+        })
+
+        break
+      }
+    }
+
+    return help.sendBackJSON(200, res, next)(
+      null,
+      schemaStore.formatForOutput(newSchema)
+    )
   } catch (error) {
     return this.handleError(error, res, next)
   }

--- a/dadi/lib/model/collections/delete.js
+++ b/dadi/lib/model/collections/delete.js
@@ -91,7 +91,7 @@ function deleteFn({client, description, query, req, validate = true}) {
         },
         query
       })
-        .then(({metadata, results}) => {
+        .then(({results}) => {
           deletedDocuments = results
 
           if (isRestIDQuery && deletedDocuments.length === 0) {
@@ -105,6 +105,8 @@ function deleteFn({client, description, query, req, validate = true}) {
           // Create a revision for each of the updated documents.
           if (this.history) {
             return this.history.addVersion(deletedDocuments, {
+              author: client && client.clientId,
+              date: Date.now(),
               description
             })
           }

--- a/dadi/lib/model/collections/update.js
+++ b/dadi/lib/model/collections/update.js
@@ -294,6 +294,8 @@ function update({
       if (this.history && updatedDocuments.length > 0) {
         return this.history
           .addVersion(updatedDocuments, {
+            author: internals._lastModifiedBy,
+            date: internals._lastModifiedAt,
             description
           })
           .then(() => response)

--- a/dadi/lib/model/history.js
+++ b/dadi/lib/model/history.js
@@ -42,7 +42,7 @@ History.prototype.addVersion = function(
     delete version._id
 
     if (typeof description === 'string' && description.length > 0) {
-      version._changeDescription = description
+      version.description = description
     }
 
     return version
@@ -74,6 +74,8 @@ History.prototype.getVersion = function(version, options = {}) {
         results: results.map(result => {
           return Object.assign({}, result, {
             _id: result._document,
+            _author: undefined,
+            _date: undefined,
             _document: undefined
           })
         }),
@@ -104,8 +106,7 @@ History.prototype.getVersions = function(documentId) {
       fields: {
         _author: 1,
         _date: 1,
-        _document: 1,
-        _changeDescription: 1
+        description: 1
       }
     },
     query: {

--- a/dadi/lib/model/history.js
+++ b/dadi/lib/model/history.js
@@ -24,11 +24,18 @@ const History = function({database, name}) {
  * Stores a version of a document as a diff.
  *
  * @param {Array<Object>} documents           Documents to add
+ * @param {String}        options.author      The client ID that generated the version
+ * @param {String}        options.date The timestamp of the change
  * @param {String}        options.description Optional message describing the operation
  */
-History.prototype.addVersion = function(documents, {description}) {
+History.prototype.addVersion = function(
+  documents,
+  {author, date, description}
+) {
   const versions = documents.map(document => {
     const version = Object.assign({}, document, {
+      _author: author,
+      _date: date,
       _document: document._id
     })
 
@@ -95,6 +102,8 @@ History.prototype.getVersions = function(documentId) {
     collection: this.name,
     options: {
       fields: {
+        _author: 1,
+        _date: 1,
         _document: 1,
         _changeDescription: 1
       }

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     ]
   },
   "dependencies": {
-    "@dadi/api-validator": "^1.2.0",
+    "@dadi/api-validator": "^1.3.1",
     "@dadi/boot": "^1.1.3",
     "@dadi/cache": "^3.0.0",
     "@dadi/et": "^2.0.0",

--- a/test/acceptance/document-versioning.js
+++ b/test/acceptance/document-versioning.js
@@ -47,31 +47,55 @@ const schema2 = Object.assign({}, schema1, {
   }
 })
 
+const MOCK_CLIENT = {
+  clientId: 'apiClient',
+  secret: 'someSecret',
+  accessType: 'admin'
+}
+const MOCK_TIME = 123456789
+const dateNow = Date.now
+
 let bearerToken
 
 describe('Document versioning', function() {
   this.timeout(4000)
 
+  before(() => {
+    Date.now = () => MOCK_TIME
+  })
+
   beforeEach(done => {
     help.dropDatabase('testdb', err => {
       app.start(() => {
         help.createSchemas([schema1, schema2]).then(() => {
-          help.getBearerTokenWithAccessType('admin', (err, token) => {
-            if (err) return done(err)
+          help.createACLClient(MOCK_CLIENT).then(() => {
+            client
+              .post(config.get('auth.tokenUrl'))
+              .set('content-type', 'application/json')
+              .send(MOCK_CLIENT)
+              .end((err, res) => {
+                if (err) return done(err)
 
-            bearerToken = token
+                bearerToken = res.body.accessToken
 
-            done()
+                done()
+              })
           })
         })
       })
     })
   })
 
+  after(() => {
+    Date.now = dateNow
+  })
+
   afterEach(done => {
     help.dropSchemas().then(() => {
-      app.stop(() => {
-        done()
+      help.removeACLData(() => {
+        app.stop(() => {
+          done()
+        })
       })
     })
   })
@@ -155,7 +179,13 @@ describe('Document versioning', function() {
                       const {results} = res.body
 
                       results.length.should.eql(2)
+
+                      results[0]._author.should.eql(MOCK_CLIENT.clientId)
+                      results[0]._date.should.eql(MOCK_TIME)
                       results[0]._document.should.eql(id)
+
+                      results[1]._author.should.eql(MOCK_CLIENT.clientId)
+                      results[1]._date.should.eql(MOCK_TIME)
                       results[1]._document.should.eql(id)
 
                       done()
@@ -226,10 +256,15 @@ describe('Document versioning', function() {
                       const {results} = res.body
 
                       results.length.should.eql(2)
+                      results[0]._author.should.eql(MOCK_CLIENT.clientId)
+                      results[0]._date.should.eql(MOCK_TIME)
                       results[0]._document.should.eql(id)
                       results[0]._changeDescription.should.eql(
                         updates[0].description
                       )
+
+                      results[1]._author.should.eql(MOCK_CLIENT.clientId)
+                      results[1]._date.should.eql(MOCK_TIME)
                       results[1]._document.should.eql(id)
                       results[1]._changeDescription.should.eql(
                         updates[1].description

--- a/test/acceptance/document-versioning.js
+++ b/test/acceptance/document-versioning.js
@@ -182,11 +182,9 @@ describe('Document versioning', function() {
 
                       results[0]._author.should.eql(MOCK_CLIENT.clientId)
                       results[0]._date.should.eql(MOCK_TIME)
-                      results[0]._document.should.eql(id)
 
                       results[1]._author.should.eql(MOCK_CLIENT.clientId)
                       results[1]._date.should.eql(MOCK_TIME)
-                      results[1]._document.should.eql(id)
 
                       done()
                     })
@@ -258,17 +256,11 @@ describe('Document versioning', function() {
                       results.length.should.eql(2)
                       results[0]._author.should.eql(MOCK_CLIENT.clientId)
                       results[0]._date.should.eql(MOCK_TIME)
-                      results[0]._document.should.eql(id)
-                      results[0]._changeDescription.should.eql(
-                        updates[0].description
-                      )
+                      results[0].description.should.eql(updates[0].description)
 
                       results[1]._author.should.eql(MOCK_CLIENT.clientId)
                       results[1]._date.should.eql(MOCK_TIME)
-                      results[1]._document.should.eql(id)
-                      results[1]._changeDescription.should.eql(
-                        updates[1].description
-                      )
+                      results[1].description.should.eql(updates[1].description)
 
                       done()
                     })


### PR DESCRIPTION
This PR:

- Changes the endpoints for managing collections to:
    - `GET /api/collections`: list collections
    - `GET /api/collections/:property/:collection`: view collection
    - `POST /api/collections`: create new collection
    - `POST /api/collections/:property/:collection/fields`: adds a field to a collection
    - `PUT /api/collections/:property/:collection/fields/:field`: updates a field's schema
    - `DELETE /api/collections/:property/:collection/fields/:field`: deletes a field
    - `PUT /api/collections/:property/:collection/settings`: updates a collection's settings
- Adds support for a `fields` URL parameter on the `/api/collections` endpoint, allowing consumers to apply a Mongo-style fields projection to the response
- Adds the fields `_author` and `_date` to the `/versions` endpoint, indicating the ID of the client that generated the change and the timestamp, respectively.