### PR TITLE
Abort app start when token key is not defined

### DIFF
--- a/config.js
+++ b/config.js
@@ -110,7 +110,8 @@ const conf = convict({
     tokenKey: {
       doc: 'The private key used to sign JWT tokens',
       format: String,
-      default: 'YOU-MUST-CHANGE-ME!'
+      default: '',
+      env: 'TOKEN_KEY'
     },
     accessCollection: {
       doc:

--- a/config/config.test.json.sample
+++ b/config/config.test.json.sample
@@ -18,7 +18,7 @@
     "tokenCollection": "token-store",
     "datastore": "./../../../test/test-connector",
     "database": "testdb",
-    "tokenKey": "automated-testing-is-pretty-suite",
+    "tokenKey": "automated-testing-is-pretty-suite"
   },
   "caching": {
     "ttl": 300,

--- a/config/config.test.json.sample
+++ b/config/config.test.json.sample
@@ -17,7 +17,8 @@
     "clientCollection": "client-store",
     "tokenCollection": "token-store",
     "datastore": "./../../../test/test-connector",
-    "database": "testdb"
+    "database": "testdb",
+    "tokenKey": "automated-testing-is-pretty-suite",
   },
   "caching": {
     "ttl": 300,


### PR DESCRIPTION
This PR stops API dead in its tracks when the JWT private key isn't defined. It also adds a `TOKEN_SECRET` environment to that effect.