### PR TITLE
Add pagination URLs to metadata block

### DIFF
--- a/dadi/lib/controller/documents.js
+++ b/dadi/lib/controller/documents.js
@@ -192,7 +192,6 @@ Collection.prototype.get = workQueue.wrapForegroundJob(async function(
 
     return done(null, results, req)
   } catch (error) {
-    console.log(error)
     return done(error)
   }
 })

--- a/dadi/lib/controller/documents.js
+++ b/dadi/lib/controller/documents.js
@@ -158,7 +158,8 @@ Collection.prototype.get = workQueue.wrapForegroundJob(async function(
   }
 
   const {id} = req.params
-  const options = this._getURLParameters(req.url)
+  const parsedUrl = url.parse(req.url, true)
+  const {query: options} = parsedUrl
   const callback = options.callback || model.settings.callback
 
   // Determine if the client supplied a JSONP callback.
@@ -182,8 +183,16 @@ Collection.prototype.get = workQueue.wrapForegroundJob(async function(
       version: id && options.version
     })
 
+    if (results.metadata) {
+      results.metadata = this._addPaginationUrlsToMetadata(
+        parsedUrl,
+        results.metadata
+      )
+    }
+
     return done(null, results, req)
   } catch (error) {
+    console.log(error)
     return done(error)
   }
 })

--- a/dadi/lib/controller/index.js
+++ b/dadi/lib/controller/index.js
@@ -1,4 +1,3 @@
-const config = require('./../../../config')
 const help = require('./../help')
 const url = require('url')
 
@@ -6,15 +5,37 @@ const ID_PATTERN = '[a-fA-F0-9-]*'
 
 const Controller = function() {}
 
-Controller.prototype._getURLParameters = function(requestUrl) {
-  const parsedUrl = url.parse(requestUrl, true)
+Controller.prototype._addPaginationUrlsToMetadata = function(
+  parsedUrl,
+  metadata
+) {
+  let urls = {}
 
-  return parsedUrl.query
+  if (metadata.nextPage) {
+    const nextPageUrl = Object.assign({query: {}}, parsedUrl, {
+      search: undefined
+    })
+
+    nextPageUrl.query.page = metadata.nextPage
+
+    urls.nextPageUrl = decodeURIComponent(url.format(nextPageUrl))
+  }
+
+  if (metadata.prevPage) {
+    const prevPageUrl = Object.assign({query: {}}, parsedUrl, {
+      search: undefined
+    })
+
+    prevPageUrl.query.page = metadata.prevPage
+
+    urls.prevPageUrl = decodeURIComponent(url.format(prevPageUrl))
+  }
+
+  return Object.assign({}, metadata, urls)
 }
 
 Controller.prototype._prepareQuery = function(req, model) {
-  const path = url.parse(req.url, true)
-  const options = this._getURLParameters(req.url)
+  const {query: options} = url.parse(req.url, true)
   let query = help.parseQuery(options.filter)
 
   // Formatting query

--- a/dadi/lib/controller/index.js
+++ b/dadi/lib/controller/index.js
@@ -9,7 +9,7 @@ Controller.prototype._addPaginationUrlsToMetadata = function(
   parsedUrl,
   metadata
 ) {
-  let urls = {}
+  const urls = {}
 
   if (metadata.nextPage) {
     const nextPageUrl = Object.assign({query: {}}, parsedUrl, {

--- a/dadi/lib/controller/media.js
+++ b/dadi/lib/controller/media.js
@@ -186,9 +186,9 @@ MediaController.prototype.delete = function(req, res, next) {
  * @return {Promise<ResultSet>}
  */
 MediaController.prototype.get = function(req, res, next) {
-  const path = url.parse(req.url, true)
+  const parsedUrl = url.parse(req.url, true)
   const query = this._prepareQuery(req, this.model)
-  const parsedOptions = this._prepareQueryOptions(path.query, this.model)
+  const parsedOptions = this._prepareQueryOptions(parsedUrl.query, this.model)
 
   if (parsedOptions.errors.length > 0) {
     return help.sendBackJSON(400, res, next)(null, parsedOptions)
@@ -205,6 +205,13 @@ MediaController.prototype.get = function(req, res, next) {
       response.results = response.results.map(document => {
         return mediaModel.formatDocuments(document)
       })
+
+      if (response.metadata) {
+        response.metadata = this._addPaginationUrlsToMetadata(
+          parsedUrl,
+          response.metadata
+        )
+      }
 
       help.sendBackJSON(200, res, next)(null, response)
     })

--- a/test/acceptance/media.js
+++ b/test/acceptance/media.js
@@ -1038,6 +1038,39 @@ describe('Media', function() {
               })
           })
         })
+
+        it('should show pagination numbers and URLs in the metadata block', function(done) {
+          const obj = {
+            fileName: '1f525.png',
+            mimetype: 'image/png'
+          }
+
+          signAndUpload(obj, (err, _) => {
+            if (err) return done(err)
+
+            signAndUpload(obj, (err, _) => {
+              if (err) return done(err)
+
+              signAndUpload(obj, (err, _) => {
+                if (err) return done(err)
+                client
+                  .get(`/media/?count=1&page=2`)
+                  .set('Authorization', `Bearer ${bearerToken}`)
+                  .end((err, res) => {
+                    const {metadata} = res.body
+
+                    metadata.totalPages.should.eql(3)
+                    metadata.prevPage.should.eql(1)
+                    metadata.prevPageUrl.should.eql(`/media/?count=1&page=1`)
+                    metadata.nextPage.should.eql(3)
+                    metadata.nextPageUrl.should.eql(`/media/?count=1&page=3`)
+
+                    done(err)
+                  })
+              })
+            })
+          })
+        })
       })
 
       describe('Named bucket', function() {

--- a/test/acceptance/rest-endpoints/collections-api/get.js
+++ b/test/acceptance/rest-endpoints/collections-api/get.js
@@ -9,7 +9,6 @@ const should = require('should')
 
 const connectionString =
   'http://' + config.get('server.host') + ':' + config.get('server.port')
-const client = request(connectionString)
 
 let bearerToken
 
@@ -744,11 +743,14 @@ describe('Collections API – GET', function() {
         .end(function(err, res) {
           if (err) return done(err)
 
-          res.body['metadata'].should.exist
-          res.body['metadata'].page.should.equal(1)
-          res.body['metadata'].limit.should.equal(docCount)
-          res.body['metadata'].totalPages.should.be.above(1) // Math.ceil(# documents/20 per page)
-          res.body['metadata'].nextPage.should.equal(2)
+          res.body.metadata.should.exist
+          res.body.metadata.page.should.equal(1)
+          res.body.metadata.limit.should.equal(docCount)
+          res.body.metadata.totalPages.should.be.above(1) // Math.ceil(# documents/20 per page)
+          res.body.metadata.nextPage.should.equal(2)
+          res.body.metadata.nextPageUrl.should.eql(
+            '/testdb/test-schema?page=2&count=' + docCount
+          )
 
           done()
         })
@@ -766,10 +768,16 @@ describe('Collections API – GET', function() {
         .end(function(err, res) {
           if (err) return done(err)
 
-          res.body['metadata'].should.exist
-          res.body['metadata'].page.should.equal(2)
-          res.body['metadata'].nextPage.should.equal(3)
-          res.body['metadata'].prevPage.should.equal(1)
+          res.body.metadata.should.exist
+          res.body.metadata.page.should.equal(2)
+          res.body.metadata.nextPage.should.equal(3)
+          res.body.metadata.nextPageUrl.should.eql(
+            '/testdb/test-schema?page=3&count=' + docCount
+          )
+          res.body.metadata.prevPage.should.equal(1)
+          res.body.metadata.prevPageUrl.should.eql(
+            '/testdb/test-schema?page=1&count=' + docCount
+          )
 
           done()
         })


### PR DESCRIPTION
Adds `prevPageUrl` and `nextPageUrl` to the metadata block on `GET` requests, indicating the URL of the previous and next page, respectively, when applicable.