### PR TITLE
fix: update stack-trace to 0.0.10

### DIFF
--- a/package.json
+++ b/package.json
@@ -60,7 +60,7 @@
     "semver": "^5.5.0",
     "serve-static": "^1.13.2",
     "sha1": "latest",
-    "stack-trace": "latest",
+    "stack-trace": "0.0.10",
     "stream-cache": "0.0.2",
     "streamifier": "^0.1.1",
     "vary": "^1.1.2"


### PR DESCRIPTION
The [stack-trace](https://github.com/felixge/node-stack-trace/) package has been published with apparent disregard to whether it works or not. The API installation references it using the `latest` tag, which naturally pulls the new incompatible version. We must pin the dependency to the last known good version 0.0.10